### PR TITLE
Add CI and auto-update settings

### DIFF
--- a/.poa-gitlab-ci.yml
+++ b/.poa-gitlab-ci.yml
@@ -1,0 +1,182 @@
+stages:
+- test
+- build
+- publish
+- optional
+
+image:                             parity/rust:gitlab-ci
+
+variables:
+  CI_SERVER_NAME:                  "GitLab CI"
+  CARGO_HOME:                      "${CI_PROJECT_DIR}/.cargo"
+  BUILD_TARGET:                    ubuntu
+  BUILD_ARCH:                      amd64
+  CARGO_TARGET:                    x86_64-unknown-linux-gnu
+
+cache:
+  key:                             "${CI_JOB_NAME}"
+  paths:
+  - ./target
+  - ./.cargo
+
+.releaseable_branches:             # list of git refs for building GitLab artifacts (think "pre-release binaries")
+  only:                            &releaseable_branches
+  - stable
+  - beta
+  - tags
+  - schedules
+
+
+.collect_artifacts:                &collect_artifacts
+  artifacts:
+    name:                          "${CI_JOB_NAME}_${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}"
+    when:                          on_success
+    expire_in:                     1 mos
+    paths:
+    - artifacts/
+
+.determine_version:                &determine_version
+- VERSION="$(sed -r -n '1,/^version/s/^version = "([^"]+)".*$/\1/p' Cargo.toml)"
+- DATE_STR="$(date +%Y%m%d)"
+- ID_SHORT="$(echo ${CI_COMMIT_SHA} | cut -c 1-7)"
+- test "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" = "nightly" && VERSION="${VERSION}-${ID_SHORT}-${DATE_STR}"
+- export VERSION
+- echo "Version = ${VERSION}"
+
+test-linux:
+  stage:                           test
+  variables:
+    RUN_TESTS:                     all
+  script:
+  - scripts/gitlab/test-all.sh stable
+  tags:
+  - rust-stable
+
+build-linux:
+  stage:                           build
+  only:                            *releaseable_branches
+  variables:
+    CARGO_TARGET:                  x86_64-unknown-linux-gnu
+  script:
+  - scripts/gitlab/build-unix.sh
+  <<:                              *collect_artifacts
+  tags:
+  - rust-stable
+
+build-darwin:
+  stage:                           build
+  only:                            *releaseable_branches
+  variables:
+    CARGO_TARGET:                  x86_64-apple-darwin
+    CC:                            gcc
+    CXX:                           g++
+  script:
+  - scripts/gitlab/build-unix.sh
+  tags:
+  - rust-osx
+  <<:                              *collect_artifacts
+
+build-windows:
+  stage:                           build
+  only:                            *releaseable_branches
+  variables:
+    CARGO_TARGET:                  x86_64-pc-windows-msvc
+  script:
+  - sh scripts/gitlab/build-windows.sh
+  tags:
+  - rust-windows
+  <<:                              *collect_artifacts
+
+publish-docker:
+  stage:                           publish
+  only:                            *releaseable_branches
+  cache: {}
+  dependencies:
+  - build-linux
+  tags:
+  - docker
+  script:
+  - scripts/gitlab/publish-docker.sh parity
+
+publish-awss3:
+  stage:                           publish
+  only:                            *releaseable_branches
+  cache: {}
+  dependencies:
+  - build-linux
+  - build-darwin
+  - build-windows
+  before_script:                   *determine_version
+  script:
+  - scripts/gitlab/publish-awss3.sh
+  tags:
+  - shell
+
+docs-jsonrpc:
+  stage:                            optional
+  only:
+  - tags
+  except:
+  - nightly
+  cache: {}
+  script:
+  - scripts/gitlab/docs-jsonrpc.sh
+  tags:
+  - shell
+
+cargo-audit:
+  stage:                           optional
+  script:
+  - scripts/gitlab/cargo-audit.sh
+  tags:
+  - rust-stable
+
+test-android:
+  stage:                           optional
+  image:                           parity/rust-android:gitlab-ci
+  variables:
+    CARGO_TARGET:                  armv7-linux-androideabi
+  script:
+  - scripts/gitlab/test-all.sh stable
+  tags:
+  - rust-arm
+
+test-darwin:
+  stage:                           optional
+  variables:
+    CARGO_TARGET:                  x86_64-apple-darwin
+    CC:                            gcc
+    CXX:                           g++
+    RUN_TESTS:                     cargo
+  script:
+  - scripts/gitlab/test-all.sh stable
+  tags:
+  - rust-osx
+
+test-windows:
+  stage:                           optional
+  variables:
+    CARGO_TARGET:                  x86_64-pc-windows-msvc
+    RUN_TESTS:                     cargo
+  script:
+  - sh scripts/gitlab/test-all.sh stable
+  tags:
+  - rust-windows
+
+test-beta:
+  stage:                           optional
+  variables:
+    RUN_TESTS:                     cargo
+  script:
+  - scripts/gitlab/test-all.sh beta
+  tags:
+  - rust-beta
+
+test-nightly:
+  stage:                           optional
+  variables:
+    RUN_TESTS:                     all
+  script:
+  - scripts/gitlab/test-all.sh nightly
+  tags:
+  - rust-nightly

--- a/ethcore/res/ethereum/poasokol.json
+++ b/ethcore/res/ethereum/poasokol.json
@@ -34,6 +34,7 @@
 		"maximumExtraDataSize": "0x20",
 		"minGasLimit": "0x1388",
 		"networkID": "0x4D",
+		"registrar" : "0xd56fb08281adf545d3af40614607d51284b014a2",
 		"eip140Transition": "0x0",
 		"eip211Transition": "0x0",
 		"eip214Transition": "0x0",

--- a/scripts/gitlab/publish-awss3.sh
+++ b/scripts/gitlab/publish-awss3.sh
@@ -6,11 +6,14 @@ set -u # treat unset variables as error
 echo "__________Register Release__________"
 DATA="secret=$RELEASES_SECRET"
 
-echo "Pushing release to Mainnet"
-./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
+#echo "Pushing release to Mainnet"
+#./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
 
-echo "Pushing release to Kovan"
-./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
+#echo "Pushing release to Kovan"
+#./scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
+
+echo "Pushing release to Sokol"
+./scripts/gitlab/safe-curl.sh $DATA "http://45.32.70.198:1339/push-release/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$CI_COMMIT_SHA"
 
 cd artifacts
 ls -l | sort -k9
@@ -29,9 +32,11 @@ do
   case $DIR in
     x86_64* )
       DATA="commit=$CI_COMMIT_SHA&sha3=$sha3&filename=parity$WIN&secret=$RELEASES_SECRET"
-      ../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
+     #../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1337/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
       # Kovan
-      ../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
+     #../../scripts/gitlab/safe-curl.sh $DATA "http://update.parity.io:1338/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
+        # Sokol
+      ../../scripts/gitlab/safe-curl.sh $DATA "http://45.32.70.198:1339/push-build/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/$DIR"
       ;;
   esac
   cd ..
@@ -41,14 +46,14 @@ echo "__________Push binaries to AWS S3____________"
 aws configure set aws_access_key_id $s3_key
 aws configure set aws_secret_access_key $s3_secret
 
-case "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" in
-  (beta|stable|nightly)
-    export S3_BUCKET=builds-parity-published;
-    ;;
-  (*)
-    export S3_BUCKET=builds-parity;
-    ;;
-esac
+#case "${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}" in
+#  (beta|stable|nightly)
+#    export S3_BUCKET=builds-parity-published;
+#    ;;
+#  (*)
+#    export S3_BUCKET=builds-parity;
+#    ;;
+#esac
 
 aws s3 sync ./ s3://$S3_BUCKET/${SCHEDULE_TAG:-${CI_COMMIT_REF_NAME}}/
 

--- a/scripts/gitlab/publish-docker.sh
+++ b/scripts/gitlab/publish-docker.sh
@@ -17,6 +17,6 @@ export DOCKER_TARGET=$1
 echo $DOCKER_TARGET
 
 echo "__________Docker build and push__________"
-docker build --build-arg TARGET=$DOCKER_TARGET --no-cache=true --tag parity/$DOCKER_TARGET:$DOCKER_BUILD_TAG -f scripts/docker/hub/Dockerfile .
-docker push parity/$DOCKER_TARGET:$DOCKER_BUILD_TAG
+docker build --build-arg TARGET=$DOCKER_TARGET --no-cache=true --tag poanetwork/$DOCKER_TARGET:$DOCKER_BUILD_TAG -f scripts/docker/hub/Dockerfile .
+docker push poanetwork/$DOCKER_TARGET:$DOCKER_BUILD_TAG
 docker logout

--- a/scripts/gitlab/sign-win.cmd
+++ b/scripts/gitlab/sign-win.cmd
@@ -1,1 +1,1 @@
-@signtool sign /f %1 /p %2 /tr http://timestamp.comodoca.com /du https://parity.io %3
+@signtool sign /f %1 /p %2 /tr http://timestamp.comodoca.com /du https://poa.network %3

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -19,6 +19,7 @@ track = "nightly"
 foundation = { forkBlock = 4370000, critical = false }
 ropsten = { forkBlock = 4230000, critical = false }
 kovan = { forkBlock = 6600000, critical = false }
+poasokol = { forkBlock = 4622420, critical = false }
 
 [dependencies]
 parity-bytes = "0.1"


### PR DESCRIPTION
Enables CI and auto-updating (for the Sokol network for now).
To run a build add tag, e.g `nightly`, tests will be run for all commits.