### PR TITLE
Added 'on_new_block' and 'on_close_block' implemenetations to Hbbft engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
  "hardware-wallet 1.12.0",
  "hashdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger?branch=hbbft-vk-extern-sender-queue)",
+ "hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1426,7 +1426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hbbft"
 version = "0.1.0"
-source = "git+https://github.com/poanetwork/hbbft?branch=vk-extern-sender-queue#11c185b5e37aadb64b2a1cf580b039ba5606aca0"
+source = "git+https://github.com/poanetwork/hbbft#b71f9142f6de0d041cde7b9f513cfca062809b2d"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "hydrabadger"
 version = "0.1.0"
-source = "git+https://github.com/poanetwork/hydrabadger?branch=hbbft-vk-extern-sender-queue#61c24ca4aa051121972a283bd2d6534948ac1569"
+source = "git+https://github.com/poanetwork/hydrabadger#2c99344c66f87e454b87bb29945f350129bede67"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1529,10 +1529,10 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "hbbft 0.1.0 (git+https://github.com/poanetwork/hbbft?branch=vk-extern-sender-queue)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hbbft 0.1.0 (git+https://github.com/poanetwork/hbbft)",
+ "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2260,15 +2260,6 @@ dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4629,7 +4620,7 @@ dependencies = [
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"
 "checksum hamming 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
 "checksum hashdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d91261ee336dd046ac7df28306cb297b7a7228bd1ae25e9a57f4ed5e0ab628c7"
-"checksum hbbft 0.1.0 (git+https://github.com/poanetwork/hbbft?branch=vk-extern-sender-queue)" = "<none>"
+"checksum hbbft 0.1.0 (git+https://github.com/poanetwork/hbbft)" = "<none>"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
@@ -4639,7 +4630,7 @@ dependencies = [
 "checksum http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "24f58e8c2d8e886055c3ead7b28793e1455270b5fb39650984c224bc538ba581"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
-"checksum hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger?branch=hbbft-vk-extern-sender-queue)" = "<none>"
+"checksum hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger)" = "<none>"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
 "checksum hyper 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)" = "95ffee0d1d30de4313fdaaa485891ce924991d45bbc18adfc8ac5b1639e62fbb"
 "checksum hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68f2aa6b1681795bf4da8063f718cd23145aa0c9a5143d9787b345aa60d38ee4"
@@ -4707,7 +4698,6 @@ dependencies = [
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-"checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -76,7 +76,7 @@ parity-runtime = { path = "../util/runtime" }
 # tokio = "0.1"
 tokio = { git = "https://github.com/tokio-rs/tokio", rev = "51e36e4" }
 # hydrabadger = { path = "../../hydrabadger"}
-hydrabadger = { git = "https://github.com/poanetwork/hydrabadger", branch = "hbbft-vk-extern-sender-queue"}
+hydrabadger = { git = "https://github.com/poanetwork/hydrabadger" }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "android"))'.dependencies]
 hardware-wallet = { path = "../hw" }

--- a/json/src/spec/hbbft.rs
+++ b/json/src/spec/hbbft.rs
@@ -16,18 +16,44 @@
 
 //! Honey Badger BFT engine params deserialization.
 
-/// Honey Badger BFT engine params deserialization.
+use hash::Address;
+use spec::ValidatorSet;
+use uint::Uint;
+
+/// `Hbbft` engine configuration parameters, this structure is used to deserialize the values found
+/// in the `Hbbft` engine's JSON spec.
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct HbbftParams {
 	/// Whether to enable millisecond timestamp.
 	#[serde(rename="millisecondTimestamp")]
 	#[serde(default)]
 	pub millisecond_timestamp: bool,
+
+	/// The block range for which each validator-set source should be used. A "validator-set
+	/// source" is either a hardcoded list of addresses or a smart contract address to query the
+	/// validator set from. The `validators` configuration option conveys information of the form:
+	/// "from block #0 to #50 use a constant list of validator addresses, for every block sealed
+	/// after block #50, query the set of validator addresses from a smart contract which is
+	/// deployed at some address".
+	pub validators: ValidatorSet,
+
+	/// The address at which the block reward contract is deployed. The block reward contract is
+	/// used to calculate block rewards, to create new POA after each new block is sealed, and to
+	/// distribute the created POA as block rewards to a set of recipient addresses.
+	pub block_reward_contract_address: Option<Address>,
+
+	/// If no `block_reward_contract_address` is provided, the `block_reward` configuration option
+	/// can be used to set a constant block reward ammount to be transfered to the address found in
+	/// each newly sealed block header's `author` field. If neither the
+	/// `block_reward_contract_address` nor `block_reward` options are supplied in the Hbbft
+	/// engine's JSON spec, no block rewards will be distributed. If values are provided for both
+	/// `block_reward_contract_address` and `block_reward`, the value for `block_reward` will be
+	/// ignored and only the contract will be queried to determine reward ammounts.
+	pub block_reward: Option<Uint>,
 }
 
 /// Honey Badger BFT engine descriptor.
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Hbbft {
-	/// Instant seal parameters.
 	pub params: HbbftParams,
 }


### PR DESCRIPTION
- Added a `.on_new_block()` method to the `Hbbft` engine to call the POA network consensus contract's `finalizeChange` function.
- Added a `.on_close_block()` method to the `Hbbft` engine to apply block rewards.
- Added new config options to the `Hbbft` engine's JSON spec.
- Updated `hydrabadger` dependency to use `master` (`hydrabadger:master` now includes the sender-queue).
- Added docs to the `Hbbft` engine.
