### PR TITLE
Fix failing chainspec tests for the 'hbbft' and 'poaindica' chainspecs

### DIFF
--- a/ethcore/res/ethereum/poaindica.json
+++ b/ethcore/res/ethereum/poaindica.json
@@ -4,10 +4,6 @@
 	"engine": {
 		"hbbft": {
 			"params": {
-				"stepDuration": 5,
-				"blockReward": "0xDE0B6B3A7640000",
-				"maximumUncleCountTransition": 0,
-				"maximumUncleCount": 0,
 				"validators": {
 					"multi": {
 						"0": {

--- a/ethcore/res/hbbft.json
+++ b/ethcore/res/hbbft.json
@@ -3,10 +3,6 @@
 	"engine": {
 		"hbbft": {
 			"params": {
-				"stepDuration": 5,
-				"blockReward": "0xDE0B6B3A7640000",
-				"maximumUncleCountTransition": 0,
-				"maximumUncleCount": 0,
 				"validators": {
 					"multi": {
 						"0": {

--- a/ethcore/src/engines/hbbft/mod.rs
+++ b/ethcore/src/engines/hbbft/mod.rs
@@ -58,7 +58,7 @@ pub struct HbbftParams {
 
 	/// If we are using a smart contract to calculate and distribute block rewards, we store the
 	/// block reward contract address here. `BlockRewardContract` has a `reward()` method that
-	/// handles the logic for serailizing the input, deserializing the output, and calling the
+	/// handles the logic for serializing the input, deserializing the output, and calling the
 	/// block reward contract's `reward()` function.
 	pub block_reward_contract: Option<BlockRewardContract>,
 
@@ -215,7 +215,7 @@ impl Engine<EthereumMachine> for Hbbft {
 	/// addresses or a smart contract that contains the validator addresses).
 	///
 	/// If the validator-set source corresponding to `block`'s block number uses a smart contract
-	/// to aquire the list of validator addresses, this method will call the smart contract's
+	/// to acquire the list of validator addresses, this method will call the smart contract's
 	/// `finalizeChange` function. The `finalizeChange` contract function will finalize any pending
 	/// validator-set changes currently known to the Safe Contract.
 	///
@@ -227,7 +227,7 @@ impl Engine<EthereumMachine> for Hbbft {
 	/// we query the list of validator addresses).
 	/// * `ancestry` - an iterator over all finalized block headers starting from the first block
 	/// for the validator-set source up to and including `block`'s parent. We ignore this argument
-	/// (it appears that every consensus engine ignores the `ancestory` argument, who knows why
+	/// (it appears that every consensus engine ignores the `ancestry` argument, who knows why
 	/// it's there).
 	fn on_new_block(
 		&self,

--- a/json/src/spec/hbbft.rs
+++ b/json/src/spec/hbbft.rs
@@ -23,9 +23,9 @@ use uint::Uint;
 /// `Hbbft` engine configuration parameters, this structure is used to deserialize the values found
 /// in the `Hbbft` engine's JSON spec.
 #[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HbbftParams {
 	/// Whether to enable millisecond timestamp.
-	#[serde(rename="millisecondTimestamp")]
 	#[serde(default)]
 	pub millisecond_timestamp: bool,
 
@@ -38,17 +38,17 @@ pub struct HbbftParams {
 	pub validators: ValidatorSet,
 
 	/// The address at which the block reward contract is deployed. The block reward contract is
-	/// used to calculate block rewards, to create new coin after each new block is sealed, and to
-	/// distribute the created coin as block rewards to a set of recipient addresses.
+	/// used to calculate block rewards, to create mint new coins after each new block is sealed, and to
+	/// distribute the minted coin as block rewards to a set of recipient addresses.
 	pub block_reward_contract_address: Option<Address>,
 
 	/// If no `block_reward_contract_address` is provided, the `block_reward` configuration option
-	/// can be used to set a constant block reward ammount to be transfered to the address found in
+	/// can be used to set a constant block reward amount to be transferred to the address found in
 	/// each newly sealed block header's `author` field. If neither the
 	/// `block_reward_contract_address` nor `block_reward` options are supplied in the Hbbft
 	/// engine's JSON spec, no block rewards will be distributed. If values are provided for both
 	/// `block_reward_contract_address` and `block_reward`, the value for `block_reward` will be
-	/// ignored and only the contract will be queried to determine reward ammounts.
+	/// ignored and only the contract will be queried to determine reward amounts.
 	pub block_reward: Option<Uint>,
 }
 


### PR DESCRIPTION
GitLab CI runs a a series of tests to ensure that all chainspecs in `ethcore/res/*.json` and `ethcore/res/ethereum/*.json` are valid. The `hbbft` and `poaindica` chainspecs are currently parse-able (i.e. don't make `cargo build` fail), but are not  totally valid. This PR fixes fixes the failing chainspec tests.

This PR includes spelling fixes for the Hbbft engine docs and the Hbbft JSON spec docs.