### PR TITLE
Added 'get_validator_set_at_block' to Hbbft engine

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -486,6 +486,10 @@ fn header_seal_hash(header: &Header, empty_steps_rlp: Option<&[u8]>) -> H256 {
 	}
 }
 
+/// Returns the number of fields that the Aura consensus engine adds to a block's header when
+/// sealing. If Aura is broadcasting `EmptyStep` messages to other validators, three seal fields
+/// will be included in the seal, otherwise the seal contains two fields. The first seal field is
+/// always the step number.
 fn header_expected_seal_fields(header: &Header, empty_steps_transition: u64) -> usize {
 	if header.number() >= empty_steps_transition {
 		3
@@ -494,6 +498,8 @@ fn header_expected_seal_fields(header: &Header, empty_steps_transition: u64) -> 
 	}
 }
 
+/// Extracts the step number from the seal found in `header`. The step number is always the first
+/// seal field for the Aura consensus engine.
 fn header_step(header: &Header, empty_steps_transition: u64) -> Result<usize, ::rlp::DecoderError> {
 	let expected_seal_fields = header_expected_seal_fields(header, empty_steps_transition);
 	Rlp::new(&header.seal().get(0).expect(
@@ -584,12 +590,16 @@ fn verify_external(header: &Header, validators: &ValidatorSet, empty_steps_trans
 	}
 }
 
+/// Creates a "combined proof". A combined proof is an 3 element RLP encoded list containing (in
+/// this order): a block number, a validator-set proof, and a finality proof.
 fn combine_proofs(signal_number: BlockNumber, set_proof: &[u8], finality_proof: &[u8]) -> Vec<u8> {
 	let mut stream = ::rlp::RlpStream::new_list(3);
 	stream.append(&signal_number).append(&set_proof).append(&finality_proof);
 	stream.out()
 }
 
+/// Destructures an RLP encoded "combined proof" into its three elements: a block number, a
+/// validator-set proof, and a finality proof.
 fn destructure_proofs(combined: &[u8]) -> Result<(BlockNumber, &[u8], &[u8]), Error> {
 	let rlp = Rlp::new(combined);
 	Ok((

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -94,6 +94,8 @@ pub enum EngineError {
 	MalformedMessage(String),
 	/// Requires client ref, but none registered.
 	RequiresClient,
+	/// No validator-set transition exists in the blockchain DB for `BlockNumber`'s parent block.
+	NoTransitionFoundForBlock(BlockNumber),
 }
 
 impl fmt::Display for EngineError {
@@ -109,6 +111,7 @@ impl fmt::Display for EngineError {
 			FailedSystemCall(ref msg) => format!("Failed to make system call: {}", msg),
 			MalformedMessage(ref msg) => format!("Received malformed consensus message: {}", msg),
 			RequiresClient => format!("Call requires client but none registered"),
+			NoTransitionFoundForBlock(ref block_number) => format!("No transition found for block number: {}", block_number),
 		};
 
 		f.write_fmt(format_args!("Engine error ({})", msg))

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -160,6 +160,8 @@ fn encode_proof(header: &Header, receipts: &[Receipt]) -> Bytes {
 	stream.drain()
 }
 
+/// Decode "inter-contract proof" which contains (in this order): a block header and a list of
+/// receipts.
 fn decode_proof(rlp: &Rlp) -> Result<(Header, Vec<Receipt>), ::error::Error> {
 	Ok((rlp.val_at(0)?, rlp.list_at(1)?))
 }


### PR DESCRIPTION
`Hbbft::get_validator_set_at_block()` is used to read, decode, and extract the validator addresses from the validator-set transition proof stored in the blockchain database for a given block.

Added documentation to:
- `ethcore/src/engines/authority_round/mod.rs`
- `ethcore/src/engines/validator_set/safe_contract.rs`