### PR TITLE
[WIP] Implement on-chain key generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
  "hardware-wallet 1.12.0",
  "hashdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger?rev=25a126a)",
+ "hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger?rev=42919d7)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,6 +826,7 @@ dependencies = [
  "rlp_derive 0.1.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "stats 0.1.0",
  "stop-guard 0.1.0",
@@ -1513,6 +1514,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hamming"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "hydrabadger"
 version = "0.1.0"
-source = "git+https://github.com/poanetwork/hydrabadger?rev=25a126a#25a126aab4fbf1b4ab0f3282b52fec7ccf1d2e27"
+source = "git+https://github.com/poanetwork/hydrabadger?rev=42919d7#42919d730a34cc014d4628051ac4e8cfd67a6c09"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3616,6 +3622,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4754,6 +4770,7 @@ dependencies = [
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum h2 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1ac030ae20dee464c5d0f36544d8b914a6bc606da44a57e052d2b0f5dae129e0"
+"checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
 "checksum hamming 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum hashdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d91261ee336dd046ac7df28306cb297b7a7228bd1ae25e9a57f4ed5e0ab628c7"
@@ -4767,7 +4784,7 @@ dependencies = [
 "checksum http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "02096a6d2c55e63f7fcb800690e4f889a25f6ec342e3adb4594e293b625215ab"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
-"checksum hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger?rev=25a126a)" = "<none>"
+"checksum hydrabadger 0.1.0 (git+https://github.com/poanetwork/hydrabadger?rev=42919d7)" = "<none>"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
 "checksum hyper 0.12.18 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd7729fc83d88353415f6816fd4bb00897aa47c7f1506b69060e74e6e3d8e8b"
 "checksum hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "68f2aa6b1681795bf4da8063f718cd23145aa0c9a5143d9787b345aa60d38ee4"
@@ -4933,6 +4950,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
 "checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
+"checksum serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45cd6d95391b16cd57e88b68be41d504183b7faae22030c0cc3b3f73dd57b2fd"
 "checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171698ce4ec7cbb93babeb3190021b4d72e96ccb98e33d277ae4ea959d6f2d9e"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -55,6 +55,7 @@ kvdb-memorydb = "0.1"
 parity-snappy = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
+serde_cbor = "0.9"
 stop-guard = { path = "../util/stop-guard" }
 macros = { path = "../util/macros" }
 rustc-hex = "1.0"
@@ -76,7 +77,7 @@ futures = "0.1"
 parity-runtime = { path = "../util/runtime" }
 tokio = "~0.1.13"
 # hydrabadger = { path = "../../hydrabadger"}
-hydrabadger = { git = "https://github.com/poanetwork/hydrabadger", rev = "25a126a"}
+hydrabadger = { git = "https://github.com/poanetwork/hydrabadger", rev = "42919d7"}
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "android"))'.dependencies]
 hardware-wallet = { path = "../hw" }

--- a/ethcore/res/contracts/hbbft/key_gen_history.json
+++ b/ethcore/res/contracts/hbbft/key_gen_history.json
@@ -1,35 +1,107 @@
 [
 	{
-		"type": "event",
-		"name": "PartWritten",
-		"inputs": [
-			{"name": "validator", "type": "address", "indexed": true},
-			{"name": "part", "type": "bytes", "indexed": false},
-			{"name": "stakingEpoch", "type": "uint256", "indexed": true},
-			{"name": "changeRequestCount", "type": "uint256", "indexed": true}
-		],
-		"anonymous": false
-	},
-	{
-		"type": "event",
-		"name": "AcktWritten",
-		"inputs": [
-			{"name": "validator", "type": "address", "indexed": true},
-			{"name": "hashOfPart", "type": "bytes32", "indexed": true},
-			{"name": "ack", "type": "bytes", "indexed": false},
-			{"name": "stakingEpoch", "type": "uint256", "indexed": false},
-			{"name": "changeRequestCount", "type": "uint256", "indexed": true}
-		],
-		"anonymous": false
-	},
-	{
-		"type": "function",
-		"name": "isKeyGenComplete",
-		"inputs": [],
-		"outputs": [
-			{"name": "", "type": "bool"}
-		],
 		"constant": false,
-		"payable": false
+		"inputs": [
+			{
+				"name": "_ack",
+				"type": "bytes"
+			}
+		],
+		"name": "writeAck",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "incrementChangeRequestCount",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_part",
+				"type": "bytes"
+			}
+		],
+		"name": "writePart",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "changeRequestCount",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"name": "validator",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "part",
+				"type": "bytes"
+			},
+			{
+				"indexed": true,
+				"name": "stakingEpoch",
+				"type": "uint256"
+			},
+			{
+				"indexed": true,
+				"name": "changeRequestCount",
+				"type": "uint256"
+			}
+		],
+		"name": "PartWritten",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"name": "validator",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "ack",
+				"type": "bytes"
+			},
+			{
+				"indexed": true,
+				"name": "stakingEpoch",
+				"type": "uint256"
+			},
+			{
+				"indexed": true,
+				"name": "changeRequestCount",
+				"type": "uint256"
+			}
+		],
+		"name": "AckWritten",
+		"type": "event"
 	}
 ]

--- a/ethcore/res/contracts/hbbft/test_junk_contract.json
+++ b/ethcore/res/contracts/hbbft/test_junk_contract.json
@@ -20,6 +20,18 @@
 		"type": "constructor"
 	},
 	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "newOwner",
+				"type": "address"
+			}
+		],
+		"name": "OwnerSet",
+		"type": "event"
+	},
+	{
 		"constant": true,
 		"inputs": [],
 		"name": "getOwner",

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -27,6 +27,7 @@ mod validator_set;
 pub mod block_reward;
 pub mod epoch;
 
+pub use self::signer::EngineSigner;
 pub use self::authority_round::AuthorityRound;
 pub use self::basic_authority::BasicAuthority;
 pub use self::epoch::{EpochVerifier, Transition as EpochTransition};

--- a/ethcore/src/hbbft/key_gen.rs
+++ b/ethcore/src/hbbft/key_gen.rs
@@ -1,0 +1,320 @@
+//! On-chain synchronous distributed key generation.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::sync::Weak;
+use std::collections::{BTreeMap, VecDeque};
+use std::cmp;
+
+use futures::sync::mpsc;
+use rand;
+use serde_cbor;
+
+use hydrabadger::{Hydrabadger, Contribution, NetworkState, Uid, WireMessage};
+use hydrabadger::hbbft::{
+	crypto::{PublicKey, SecretKey},
+	sync_key_gen::{Ack, AckOutcome, Part, PartOutcome, SyncKeyGen, Error as SyncKeyGenError},
+};
+use ethereum_types::{U256, Address};
+use types::{ids::TransactionId, receipt::LocalizedReceipt, filter::Filter, BlockNumber};
+use ethkey::Password;
+use account_provider::AccountProvider;
+use transaction::{Transaction, Action, SignedTransaction, Error as TransactionError};
+use client::{BlockChainClient, Client, ClientConfig, BlockId, ChainInfo, BlockInfo, PrepareOpenBlock,
+	ImportSealedBlock, ImportBlock, CallContract};
+use miner::MinerService;
+
+pub(super) const KEY_GEN_HISTORY_CONTRACT_HEX: &'static str = "608060405234801561001057600080fd5b50610521806100206000396000f300608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630625db39146100675780631c0e378a146100d05780633f8e80dc146100e7578063d207778214610150575b600080fd5b34801561007357600080fd5b506100ce600480360381019080803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919291929050505061017b565b005b3480156100dc57600080fd5b506100e561037c565b005b3480156100f357600080fd5b5061014e600480360381019080803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919291929050505061038f565b005b34801561015c57600080fd5b506101656104ef565b6040518082815260200191505060405180910390f35b60003073ffffffffffffffffffffffffffffffffffffffff1663d20777826040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b1580156101e157600080fd5b505af11580156101f5573d6000803e3d6000fd5b505050506040513d602081101561020b57600080fd5b81019080805190602001909291905050505060009050600054813373ffffffffffffffffffffffffffffffffffffffff167f0d1b06290384e9fafa6b46d168dfd792abb701025c0c2e77068fd00881368c64856040518080602001828103825283818151815260200191508051906020019080838360005b8381101561029e578082015181840152602081019050610283565b50505050905090810190601f1680156102cb5780820380516001836020036101000a031916815260200191505b509250505060405180910390a43073ffffffffffffffffffffffffffffffffffffffff1663d20777826040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b15801561033c57600080fd5b505af1158015610350573d6000803e3d6000fd5b505050506040513d602081101561036657600080fd5b8101908080519060200190929190505050505050565b6000808154809291906001019190505550565b6000809050600054813373ffffffffffffffffffffffffffffffffffffffff167f273e48fa7559da80314de89c5630a09b8673a98f4e81612decf00cb73345c592856040518080602001828103825283818151815260200191508051906020019080838360005b838110156104115780820151818401526020810190506103f6565b50505050905090810190601f16801561043e5780820380516001836020036101000a031916815260200191505b509250505060405180910390a43073ffffffffffffffffffffffffffffffffffffffff1663d20777826040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b1580156104af57600080fd5b505af11580156104c3573d6000803e3d6000fd5b505050506040513d60208110156104d957600080fd5b8101908080519060200190929190505050505050565b600054815600a165627a7a7230582038b1dbd02cabdf8e6d0ca90e7457a2bd99d06ecf7a21a54f499e3c934a169c8b0029";
+
+use_contract!(key_gen_history, "res/contracts/hbbft/key_gen_history.json");
+
+// TODO (c0gent): Replace error_chain with failure.
+error_chain! {
+	types {
+		Error, ErrorKind, ErrorResultExt, HbbftKeyGenResult;
+	}
+
+	errors {
+		#[doc = "A SyncKeyGen creation error."]
+		SyncKeyGenNew(err: SyncKeyGenError) {
+			description("Unable to create a SyncKeyGen instance")
+			display("Unable to create a SyncKeyGen instance: {:?}", err)
+		}
+		#[doc = "A CBOR serialization error."]
+		CborSerializeError(err: serde_cbor::error::Error) {
+			description("CBOR serialization error")
+			display("CBOR serialization error: {:?}", err)
+		}
+		#[doc = "Client has been dropped."]
+		ClientDropped {
+			description("Client has been dropped")
+			display("Client has been dropped")
+		}
+		#[doc = "TransactionImport."]
+		TransactionImport(err: TransactionError) {
+			description("Error importing transaction")
+			display("Error importing transaction: {:?}", err)
+		}
+		#[doc = "UnknownAccountNonce."]
+		UnknownAccountNonce(addr: Address) {
+			description("Unable to determine nonce for account")
+			display("Unable to determine nonce for account with address: {}", addr)
+		}
+	}
+}
+
+/// An on-chain synchronous distributed key generation instance.
+pub struct KeyGen {
+	sync_key_gen: SyncKeyGen<Address>,
+	validator_count: usize,
+	part_count: usize,
+	ack_count: usize,
+	signing_address: Address,
+	signing_password: Password,
+	signing_account_nonce: U256,
+	contract_address: Address,
+	client: Weak<Client>,
+	account_provider: Arc<AccountProvider>,
+	last_block_read: BlockNumber,
+}
+
+impl KeyGen {
+	/// Creates and returns a new `KeyGen` instance.
+	pub fn new(
+		mut peer_public_keys: BTreeMap<Address, PublicKey>,
+		local_nid: &Address,
+		local_sk: SecretKey,
+		signing_address: Address,
+		signing_password: Password,
+		contract_address: Address,
+		client: Weak<Client>,
+		account_provider: Arc<AccountProvider>,
+	) -> Result<KeyGen, Error> {
+		let local_pk = local_sk.public_key();
+		peer_public_keys.insert(*local_nid, local_pk);
+		let public_keys = peer_public_keys;
+
+		let validator_count = public_keys.len();
+		let threshold = validator_count / 3;
+
+		let mut rng = rand::OsRng::new().expect("Creating OS Rng has failed");
+
+		let (sync_key_gen, opt_part) = SyncKeyGen::new(
+			&mut rng,
+			*local_nid,
+			local_sk,
+			public_keys.clone(),
+			threshold,
+		)
+		.map_err(ErrorKind::SyncKeyGenNew)?;
+
+		// TODO: Do something else when we're not a validator:
+		let part = opt_part.expect("This node is not a validator");
+
+		let client_arc = client.upgrade().ok_or(ErrorKind::ClientDropped)?;
+		let latest_block_num = client_arc.block_number(BlockId::Latest)
+			.expect("Unable to determine latest block number");
+
+		let mut kg = KeyGen {
+			sync_key_gen,
+			validator_count,
+			ack_count: 0,
+			part_count: 0,
+			signing_address,
+			signing_password,
+			signing_account_nonce: 0.into(),
+			contract_address,
+			client,
+			account_provider,
+			last_block_read: latest_block_num,
+		};
+
+		kg.write_part(&part, &client_arc)?;
+
+		Ok(kg)
+	}
+
+	/// Converts an unsigned `Transaction` to a `SignedTransaction`.
+	fn sign_txn(&self, txn: Transaction, chain_id: Option<u64>) -> SignedTransaction {
+		let txn_hash = txn.hash(chain_id);
+		let sig = self.account_provider.sign(self.signing_address, Some(self.signing_password.clone()), txn_hash)
+			.unwrap_or_else(|e| panic!("[hbbft-lab] failed to sign txn: {:?}", e));
+		let unverified_txn = txn.with_signature(sig, chain_id);
+		SignedTransaction::new(unverified_txn).unwrap()
+	}
+
+	/// Pushes a contract call transaction to the queue.
+	//
+	// TODO: Add a mechanism to ensure each transaction is added to a block.
+	// Retry if a transaction is skipped.
+	fn call_contract(&mut self, data: Vec<u8>, client: &Client) -> Result<(), Error> {
+		let signer_nonce_state = client.state().nonce(&self.signing_address)
+			.map_err(|_| ErrorKind::UnknownAccountNonce(self.signing_address))?;
+		let signer_nonce = cmp::max(signer_nonce_state, self.signing_account_nonce);
+
+		let txn_signed = self.sign_txn(
+			Transaction {
+				action: Action::Call(self.contract_address),
+				nonce: signer_nonce,
+				// gas_price: client.miner().sensible_gas_price(),
+				gas_price: 0.into(),
+				gas: client.miner().sensible_gas_limit(),
+				value: 0.into(),
+				data,
+			},
+			client.signing_chain_id(),
+		);
+
+		client.miner().import_claimed_local_transaction(&*client, txn_signed.into(), false)
+			.map_err(ErrorKind::TransactionImport)?;
+		info!("KEY GENERATION: Transaction imported...");
+		self.signing_account_nonce += 1.into();
+		Ok(())
+	}
+
+	/// Calls the `WritePart` contract function.
+	fn write_part(&mut self, part: &Part, client: &Client) -> Result<(), Error> {
+		let data = key_gen_history::functions::write_part::encode_input(
+			serde_cbor::to_vec(part).map_err(ErrorKind::CborSerializeError)?);
+		self.call_contract(data, client)
+	}
+
+	/// Calls the `WriteAck` contract function.
+	fn write_ack(&mut self, ack: &Ack, client: &Client) -> Result<(), Error> {
+		let data = key_gen_history::functions::write_ack::encode_input(
+			serde_cbor::to_vec(ack).map_err(ErrorKind::CborSerializeError)?);
+		self.call_contract(data, client)
+	}
+
+	/// Forwards an `Ack` to a `SyncKeyGen` instance.
+	fn handle_ack(&mut self, nid: &Address, ack: Ack) {
+		trace!("KEY GENERATION: Handling ack from '{}'...", nid);
+		let ack_outcome = self.sync_key_gen
+			.handle_ack(nid, ack)
+			.expect("Failed to handle Ack.");
+		match ack_outcome {
+			AckOutcome::Invalid(fault) => error!("Error handling ack: \n{:?}", fault),
+			AckOutcome::Valid => self.ack_count += 1,
+		}
+	}
+
+	/// Handles a received `Part`.
+	//
+	// TODO: Error handling.
+	pub fn handle_part_event(
+		&mut self,
+		src_nid: &Address,
+		part: Part,
+	) -> Result<(), Error>{
+		trace!("KEY GENERATION: Handling part from '{}'...", src_nid);
+		let mut rng = rand::OsRng::new().expect("Creating OS Rng has failed");
+
+		let ack = match self.sync_key_gen.handle_part(&mut rng, src_nid, part) {
+			Ok(PartOutcome::Valid(Some(ack))) => ack,
+			Ok(PartOutcome::Invalid(faults)) => {
+				panic!("Invalid part: {:?}", faults);
+			}
+			Ok(PartOutcome::Valid(None)) => {
+				error!("`SyncKeyGen::handle_part` returned `None`.");
+				return Ok(());
+			}
+			Err(err) => {
+				error!("Error handling Part: {:?}", err);
+				return Ok(());
+			}
+		};
+
+		self.part_count += 1;
+
+		trace!("KEY GENERATION: Handling `Ack`.");
+		self.handle_ack(src_nid, ack.clone());
+
+		trace!(
+			"KEY GENERATION: Part from '{}' acknowledged. Broadcasting ack...",
+			src_nid
+		);
+		let client = self.client.upgrade().ok_or(ErrorKind::ClientDropped)?;
+		self.write_ack(&ack, &client)?;
+
+		Ok(())
+	}
+
+	/// Handles a received `Ack`.
+	pub fn handle_ack_event(
+		&mut self,
+		src_nid: &Address,
+		ack: Ack,
+	) -> Result<bool, Error> {
+		self.handle_ack(src_nid, ack.clone());
+
+		let node_n = self.validator_count;
+
+		// TODO: Consider modifying this to ~:
+		// `sync_key_gen.count_complete() >= num_nodes - num_faulty`.
+		if self.sync_key_gen.count_complete() == node_n
+			&& self.ack_count >= node_n * node_n
+		{
+			info!("KEY GENERATION: All acks received and handled.");
+
+			assert!(self.sync_key_gen.is_ready());
+			Ok(true)
+		} else {
+			Ok(false)
+		}
+	}
+
+	/// Reads the blockchain for events and handles parts and acks
+	/// appropriately.
+	pub fn handle_events(&mut self) -> Result<(), Error> {
+		info!("KEY GENERATION: Handling events...");
+
+		let client = self.client.upgrade().ok_or(ErrorKind::ClientDropped)?;
+		let latest_block_num = client.block_number(BlockId::Latest)
+			.expect("Unable to determine latest block number");
+
+		let filter = Filter {
+			from_block: BlockId::Number(self.last_block_read + 1),
+			to_block: BlockId::Number(latest_block_num),
+			address: Some(vec![self.contract_address]),
+			topics: vec![],
+			limit: None,
+		};
+
+		let logs = client.logs(filter).unwrap_or_default();
+
+		let parts = logs.iter()
+			.filter_map(|entry| {
+				let event = key_gen_history::events::part_written::parse_log(
+					(entry.topics.clone(), entry.data.clone()).into()
+				).ok()?;
+				serde_cbor::from_slice(&event.part).ok()
+					.map(|part: Part| {
+						self.handle_part_event(&event.validator.into(), part.clone())?;
+						Ok((part, event.validator.into()))
+					})
+			})
+			.collect::<Result<Vec<(Part, Address)>, Error>>()?;
+
+		info!("KEY GENERATION: Parsed Parts: {:?}", parts);
+
+		let acks = logs.iter()
+			.filter_map(|entry| {
+				let event = key_gen_history::events::ack_written::parse_log(
+					(entry.topics.clone(), entry.data.clone()).into()
+				).ok()?;
+				serde_cbor::from_slice(&event.ack).ok()
+					.map(|ack: Ack| {
+						self.handle_ack_event(&event.validator.into(), ack.clone())?;
+						Ok((ack, event.validator.into()))
+					})
+			})
+			.collect::<Result<Vec<(Ack, Address)>, Error>>()?;
+
+		info!("KEY GENERATION: Parsed Acks: {:?}", acks);
+
+
+		self.last_block_read = latest_block_num;
+		Ok(())
+	}
+}

--- a/ethcore/src/hbbft/mod.rs
+++ b/ethcore/src/hbbft/mod.rs
@@ -4,7 +4,7 @@
 
 mod daemon;
 mod laboratory;
-mod keygen;
+mod key_gen;
 
 use std::str::FromStr;
 use std::collections::HashSet;

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -93,6 +93,7 @@ extern crate rlp_compress;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
 extern crate serde_derive;
+extern crate serde_cbor;
 extern crate keccak_hash as hash;
 extern crate keccak_hasher;
 extern crate heapsize;


### PR DESCRIPTION
Runs a `SyncKeyGen` instance using the blockchain as the communications channel.

### Unfinished

- [X] Forward parsed `Ack` and `Part` events.
	- [X] Change Hydrabadger node ids to `ethereum_types::Address`.
- [ ] Ensure Part and Ack-containing transactions are added to a block.
- [ ] Store contract in genesis block (What's the correct way to calculate the contract's address?).

### For future PRs

- [ ] Complete work on validator contracts and properly combine key generation with it.
- [ ] Use completed key generation instances to create new Honey Badger instances (beginning new staking epochs/weeks/terms/whatever).