### PR TITLE
Call `get_pending_validators`

### DIFF
--- a/ethcore/res/contracts/authority_round_random.json
+++ b/ethcore/res/contracts/authority_round_random.json
@@ -1,4 +1,5 @@
-[{
+[
+	{
 		"constant": true,
 		"inputs": [],
 		"name": "COMMIT_PHASE_LENGTH",

--- a/ethcore/res/contracts/validator_set.json
+++ b/ethcore/res/contracts/validator_set.json
@@ -1,5 +1,6 @@
 [
 	{"constant":false,"inputs":[],"name":"finalizeChange","outputs":[],"payable":false,"type":"function"},
 	{"constant":true,"inputs":[],"name":"getValidators","outputs":[{"name":"validators","type":"address[]"}],"payable":false,"type":"function"},
-	{"anonymous":false,"inputs":[{"indexed":true,"name":"_parent_hash","type":"bytes32"},{"indexed":false,"name":"_new_set","type":"address[]"}],"name":"InitiateChange","type":"event"}
+	{"anonymous":false,"inputs":[{"indexed":true,"name":"_parent_hash","type":"bytes32"},{"indexed":false,"name":"_new_set","type":"address[]"}],"name":"InitiateChange","type":"event"},
+	{"constant":true,"inputs":[],"name":"getPendingValidators","outputs":[{"name":"","type":"address[]"}],"payable":false,"stateMutability":"view","type":"function"}
 ]

--- a/ethcore/src/engines/authority_round/randomness.rs
+++ b/ethcore/src/engines/authority_round/randomness.rs
@@ -19,7 +19,7 @@ use super::util::{BoundContract, CallError};
 //       this reason we store the raw buffers.
 pub type Secret = [u8; 32];
 
-use_contract!(aura_random, "res/authority_round_random.json");
+use_contract!(aura_random, "res/contracts/authority_round_random.json");
 
 /// Validated randomness phase state.
 ///

--- a/ethcore/src/engines/validator_set/contract.rs
+++ b/ethcore/src/engines/validator_set/contract.rs
@@ -27,6 +27,7 @@ use client::EngineClient;
 use header::{Header, BlockNumber};
 use machine::{AuxiliaryData, Call, EthereumMachine};
 use transaction::Action;
+use ethjson::spec::authority_round::ConsensusKind;
 
 use super::{ValidatorSet, SimpleList, SystemCall};
 use super::safe_contract::ValidatorSafeContract;
@@ -41,10 +42,10 @@ pub struct ValidatorContract {
 }
 
 impl ValidatorContract {
-	pub fn new(contract_address: Address) -> Self {
+	pub fn new(contract_address: Address, consensus_kind: ConsensusKind) -> Self {
 		ValidatorContract {
 			contract_address,
-			validators: ValidatorSafeContract::new(contract_address),
+			validators: ValidatorSafeContract::new(contract_address, consensus_kind),
 			client: RwLock::new(None),
 		}
 	}
@@ -147,16 +148,18 @@ mod tests {
 	use test_helpers::generate_dummy_client_with_spec_and_accounts;
 	use client::{BlockChainClient, ChainInfo, BlockInfo, CallContract};
 	use super::super::ValidatorSet;
-	use super::ValidatorContract;
+	use super::{ValidatorContract, ConsensusKind};
 
 	#[test]
 	fn fetches_validators() {
 		let client = generate_dummy_client_with_spec_and_accounts(Spec::new_validator_contract, None);
-		let vc = Arc::new(ValidatorContract::new("0000000000000000000000000000000000000005".parse::<Address>().unwrap()));
-		vc.register_client(Arc::downgrade(&client) as _);
-		let last_hash = client.best_block_header().hash();
-		assert!(vc.contains(&last_hash, &"7d577a597b2742b498cb5cf0c26cdcd726d39e6e".parse::<Address>().unwrap()));
-		assert!(vc.contains(&last_hash, &"82a978b3f5962a5b0957d9ee9eef472ee55b42f1".parse::<Address>().unwrap()));
+		for &i in &[ConsensusKind::Poa, ConsensusKind::Pos] {
+			let vc = Arc::new(ValidatorContract::new("0000000000000000000000000000000000000005".parse::<Address>().unwrap(), i));
+			vc.register_client(Arc::downgrade(&client) as _);
+			let last_hash = client.best_block_header().hash();
+			assert!(vc.contains(&last_hash, &"7d577a597b2742b498cb5cf0c26cdcd726d39e6e".parse::<Address>().unwrap()));
+			assert!(vc.contains(&last_hash, &"82a978b3f5962a5b0957d9ee9eef472ee55b42f1".parse::<Address>().unwrap()));
+		}
 	}
 
 	#[test]

--- a/ethcore/src/engines/validator_set/mod.rs
+++ b/ethcore/src/engines/validator_set/mod.rs
@@ -31,6 +31,7 @@ use ethjson::spec::ValidatorSet as ValidatorSpec;
 use client::EngineClient;
 use header::{Header, BlockNumber};
 use machine::{AuxiliaryData, Call, EthereumMachine};
+use ethjson::spec::authority_round::ConsensusKind;
 
 #[cfg(test)]
 pub use self::test::TestSet;
@@ -44,8 +45,10 @@ use super::SystemCall;
 pub fn new_validator_set(spec: ValidatorSpec) -> Box<ValidatorSet> {
 	match spec {
 		ValidatorSpec::List(list) => Box::new(SimpleList::new(list.into_iter().map(Into::into).collect())),
-		ValidatorSpec::SafeContract(address) => Box::new(ValidatorSafeContract::new(address.into())),
-		ValidatorSpec::Contract(address) => Box::new(ValidatorContract::new(address.into())),
+		ValidatorSpec::SafeContractCallGetPendingValidators(address) => Box::new(ValidatorSafeContract::new(address.into(), ConsensusKind::Poa)),
+		ValidatorSpec::SafeContract(address) => Box::new(ValidatorSafeContract::new(address.into(), ConsensusKind::Pos)),
+		ValidatorSpec::Contract(address) => Box::new(ValidatorContract::new(address.into(), ConsensusKind::Pos)),
+		ValidatorSpec::ContractCallGetPendingValidators(address) => Box::new(ValidatorContract::new(address.into(), ConsensusKind::Poa)),
 		ValidatorSpec::Multi(sequence) => Box::new(
 			Multi::new(sequence.into_iter().map(|(block, set)| (block.into(), new_validator_set(set))).collect())
 		),

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -18,12 +18,11 @@
 
 use bytes::Bytes;
 use client::EngineClient;
-use ethereum_types::{H256, U256, Address, Bloom};
+use ethereum_types::{H256, U256, Address};
 use hash::keccak;
 use header::Header;
 use ids::BlockId;
 use kvdb::DBValue;
-use log_entry::LogEntry;
 use machine::{AuxiliaryData, Call, EthereumMachine, AuxiliaryRequest};
 use memory_cache::MemoryLruCache;
 use parking_lot::RwLock;
@@ -34,6 +33,9 @@ use super::{SystemCall, ValidatorSet};
 use super::simple_list::SimpleList;
 use unexpected::Mismatch;
 use ethabi::FunctionOutputDecoder;
+use ethjson::spec::authority_round::ConsensusKind;
+use types::log_entry::LogEntry;
+use ethereum_types::Bloom;
 
 use_contract!(validator_set, "res/contracts/validator_set.json");
 
@@ -74,6 +76,7 @@ pub struct ValidatorSafeContract {
 	contract_address: Address,
 	validators: RwLock<MemoryLruCache<H256, SimpleList>>,
 	client: RwLock<Option<Weak<EngineClient>>>, // TODO [keorn]: remove
+	consensus_kind: ConsensusKind,
 }
 
 // first proof is just a state proof call of `getValidators` at header's state.
@@ -189,11 +192,12 @@ fn prove_initial(contract_address: Address, header: &Header, caller: &Call) -> R
 }
 
 impl ValidatorSafeContract {
-	pub fn new(contract_address: Address) -> Self {
+	pub fn new(contract_address: Address, consensus_kind: ConsensusKind) -> Self {
 		ValidatorSafeContract {
 			contract_address,
 			validators: RwLock::new(MemoryLruCache::new(MEMOIZE_CAPACITY)),
 			client: RwLock::new(None),
+			consensus_kind,
 		}
 	}
 
@@ -272,6 +276,15 @@ impl ValidatorSafeContract {
 			Some(matched_event) => Some(SimpleList::new(matched_event.new_set))
 		}
 	}
+
+	// check receipts for block.
+	fn extract_from_block(&self, caller: Box<Call>) -> Option<SimpleList> {
+		let data = validator_set::functions::get_pending_validators::encode_input();
+		caller(self.contract_address, data)
+			.ok()
+			.and_then(|x| validator_set::functions::get_pending_validators::decode_output(&x.0).ok())
+			.map(SimpleList::new)
+	}
 }
 
 impl ValidatorSet for ValidatorSafeContract {
@@ -320,17 +333,24 @@ impl ValidatorSet for ValidatorSafeContract {
 			return ::engines::EpochChange::Yes(::engines::Proof::WithState(state_proof as Arc<_>));
 		}
 
-		// otherwise, we're checking for logs.
-		let bloom = self.expected_bloom(header);
-		let header_bloom = header.log_bloom();
-
-		if &bloom & header_bloom != bloom { return ::engines::EpochChange::No }
+		let bloom = match self.consensus_kind {
+			ConsensusKind::Poa => None,
+			ConsensusKind::Pos => {
+				let bloom = self.expected_bloom(header);
+				let header_bloom = header.log_bloom();
+				if &bloom & header_bloom != bloom { return ::engines::EpochChange::No }
+				Some(bloom)
+			}
+		};
 
 		trace!(target: "engine", "detected epoch change event bloom");
 
 		match receipts {
 			None => ::engines::EpochChange::Unsure(AuxiliaryRequest::Receipts),
-			Some(receipts) => match self.extract_from_event(bloom, header, receipts) {
+			Some(receipts) => match match bloom {
+				None => self.extract_from_block(self.default_caller(BlockId::Number(header.number()))),
+				Some(bloom) => self.extract_from_event(bloom, header, receipts),
+			} {
 				None => ::engines::EpochChange::No,
 				Some(list) => {
 					info!(target: "engine", "Signal for transition within contract. New list: {:?}",
@@ -343,7 +363,7 @@ impl ValidatorSet for ValidatorSafeContract {
 		}
 	}
 
-	fn epoch_set(&self, first: bool, machine: &EthereumMachine, _number: ::header::BlockNumber, proof: &[u8])
+	fn epoch_set(&self, first: bool, machine: &EthereumMachine, number: ::header::BlockNumber, proof: &[u8])
 		-> Result<(SimpleList, Option<H256>), ::error::Error>
 	{
 		let rlp = Rlp::new(proof);
@@ -375,9 +395,10 @@ impl ValidatorSet for ValidatorSafeContract {
 				).into());
 			}
 
-			let bloom = self.expected_bloom(&old_header);
-
-			match self.extract_from_event(bloom, &old_header, &receipts) {
+			match match self.consensus_kind {
+				ConsensusKind::Poa => self.extract_from_block(self.default_caller(BlockId::Number(number))),
+				ConsensusKind::Pos => self.extract_from_event(self.expected_bloom(&old_header), &old_header, &receipts),
+			} {
 				Some(list) => Ok((list, Some(old_header.hash()))),
 				None => Err(::engines::EngineError::InsufficientProof("No log event in proof.".into()).into()),
 			}
@@ -450,17 +471,19 @@ mod tests {
 	use miner::MinerService;
 	use test_helpers::{generate_dummy_client_with_spec_and_accounts, generate_dummy_client_with_spec_and_data};
 	use super::super::ValidatorSet;
-	use super::{ValidatorSafeContract, EVENT_NAME_HASH};
+	use super::{ValidatorSafeContract, EVENT_NAME_HASH, ConsensusKind};
 	use verification::queue::kind::blocks::Unverified;
 
 	#[test]
 	fn fetches_validators() {
 		let client = generate_dummy_client_with_spec_and_accounts(Spec::new_validator_safe_contract, None);
-		let vc = Arc::new(ValidatorSafeContract::new("0000000000000000000000000000000000000005".parse::<Address>().unwrap()));
-		vc.register_client(Arc::downgrade(&client) as _);
-		let last_hash = client.best_block_header().hash();
-		assert!(vc.contains(&last_hash, &"7d577a597b2742b498cb5cf0c26cdcd726d39e6e".parse::<Address>().unwrap()));
-		assert!(vc.contains(&last_hash, &"82a978b3f5962a5b0957d9ee9eef472ee55b42f1".parse::<Address>().unwrap()));
+		for &i in &[ConsensusKind::Poa, ConsensusKind::Pos] {
+			let vc = Arc::new(ValidatorSafeContract::new("0000000000000000000000000000000000000005".parse::<Address>().unwrap(), i));
+			vc.register_client(Arc::downgrade(&client) as _);
+			let last_hash = client.best_block_header().hash();
+			assert!(vc.contains(&last_hash, &"7d577a597b2742b498cb5cf0c26cdcd726d39e6e".parse::<Address>().unwrap()));
+			assert!(vc.contains(&last_hash, &"82a978b3f5962a5b0957d9ee9eef472ee55b42f1".parse::<Address>().unwrap()));
+		}
 	}
 
 	#[test]

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -21,7 +21,7 @@ use uint::Uint;
 use bytes::Bytes;
 use super::ValidatorSet;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Copy, Clone, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum ConsensusKind {
 	Poa,

--- a/json/src/spec/validator_set.rs
+++ b/json/src/spec/validator_set.rs
@@ -27,10 +27,14 @@ use hash::Address;
 pub enum ValidatorSet {
 	/// A simple list of authorities.
 	List(Vec<Address>),
+	/// Address of a contract that indicates the list of authorities, and uses `getPendingValidators` instead of the `InitiateChange` event.
+	SafeContractCallGetPendingValidators(Address),
 	/// Address of a contract that indicates the list of authorities.
 	SafeContract(Address),
-	/// Address of a contract that indicates the list of authorities and enables reporting of theor misbehaviour using transactions.
+	/// Address of a contract that indicates the list of authorities and enables reporting of their misbehaviour using transactions.
 	Contract(Address),
+	/// Address of a contract that indicates the list of authorities, enables reporting of their misbehaviour using transactions, and uses `getPendingValidators` instead of the `InitiateChange` event.
+	ContractCallGetPendingValidators(Address),
 	/// A map of starting blocks for each validator set.
 	Multi(BTreeMap<Uint, ValidatorSet>),
 }

--- a/test.sh
+++ b/test.sh
@@ -35,9 +35,9 @@ validate () {
   if [ "$VALIDATE" -eq "1" ]
   then
     echo "________Validate build________"
-    time cargo check $@ --frozen --no-default-features
-    time cargo check $@ --frozen --manifest-path util/io/Cargo.toml --no-default-features
-    time cargo check $@ --frozen --manifest-path util/io/Cargo.toml --features "mio"
+    time cargo check "$@" --frozen --no-default-features
+    time cargo check "$@" --frozen --manifest-path util/io/Cargo.toml --no-default-features
+    time cargo check "$@" --frozen --manifest-path util/io/Cargo.toml --features "mio"
 
     # Validate chainspecs
     echo "________Validate chainspecs________"
@@ -71,7 +71,7 @@ cpp_test () {
 cargo_test () {
   echo "________Running Parity Full Test Suite________"
   git submodule update --init --recursive
-  time cargo test $OPTIONS --features "$FEATURES" --frozen --all $@ -- --test-threads $THREADS
+  time cargo test $OPTIONS --features "$FEATURES" --frozen --all "$@" -- --test-threads $THREADS
 }
 
 
@@ -89,12 +89,12 @@ then
 
   case "${RUN_TESTS}" in
     (cargo|all)
-      cargo_test --target $CARGO_TARGET $@
+      cargo_test --target $CARGO_TARGET "$@"
       ;;
     ('')
-      cargo_test --no-run --target $CARGO_TARGET $@
+      cargo_test --no-run --target $CARGO_TARGET "$@"
       ;;
   esac
 else
-  cargo_test $@
+  cargo_test "$@"
 fi


### PR DESCRIPTION
instead of relying on the `InitiateChange` event.

Closes #49.