### PR TITLE
Minor improvements to report_malicious

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1252,7 +1252,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 			|| (header.number() >= self.validate_step_transition && step <= parent_step) {
 			trace!(target: "engine", "Multiple blocks proposed for step {}.", parent_step);
 
-			self.validators.report_malicious(header.author(), set_number, header.number(), &mut |hash| self.sign(hash).expect("bug"));
+			self.validators.report_malicious(header.author(), set_number, header.number(), &|hash| self.sign(hash))?;
 			Err(EngineError::DoubleVote(*header.author()))?;
 		}
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,16 +1,8 @@
-verbose=false
 max_width=100
 comment_width=100
 tab_spaces=4
-fn_call_width=100
-struct_lit_width=32
-fn_call_style="Visual"
-single_line_if_else_max_width=100
 trailing_comma="Vertical"
-chain_indent="Visual"
-chain_one_line_max=100
 reorder_imports=true
 format_strings=false
 hard_tabs=true
-wrap_match_arms=false
 error_on_line_overflow=false


### PR DESCRIPTION
- The function argument was made immutable as it should be.

- The returned `Error` is passed to the caller instead of being forgotten.

- Formatted the changed files with `rustfmt`.

- Corrected the `rustfmt` config file to work with the up to date version of `rustfmt`.