### PR TITLE
Minor changes in reporting malicious validator in AuRa

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1252,7 +1252,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 			|| (header.number() >= self.validate_step_transition && step <= parent_step) {
 			trace!(target: "engine", "Multiple blocks proposed for step {}.", parent_step);
 
-			self.validators.report_malicious(header.author(), set_number, header.number(), &mut |hash| self.sign(hash).expect("bug"));
+			self.validators.report_malicious(header.author(), set_number, header.number(), &|hash| self.sign(hash))?;
 			Err(EngineError::DoubleVote(*header.author()))?;
 		}
 

--- a/ethcore/src/engines/validator_set/mod.rs
+++ b/ethcore/src/engines/validator_set/mod.rs
@@ -39,6 +39,7 @@ use self::safe_contract::ValidatorSafeContract;
 use self::multi::Multi;
 use super::SystemCall;
 use ethkey::Signature;
+use error::Error;
 
 /// Creates a validator set from spec.
 pub fn new_validator_set(spec: ValidatorSpec) -> Box<ValidatorSet> {
@@ -85,7 +86,7 @@ pub trait ValidatorSet: Send + Sync + 'static {
 	/// The caller provided here may not generate proofs.
 	///
 	/// `first` is true if this is the first block in the set.
-	fn on_epoch_begin(&self, _first: bool, _header: &Header, _call: &mut SystemCall) -> Result<(), ::error::Error> {
+	fn on_epoch_begin(&self, _first: bool, _header: &Header, _call: &mut SystemCall) -> Result<(), Error> {
 		Ok(())
 	}
 
@@ -121,7 +122,7 @@ pub trait ValidatorSet: Send + Sync + 'static {
 	/// Returns the set, along with a flag indicating whether finality of a specific
 	/// hash should be proven.
 	fn epoch_set(&self, first: bool, machine: &EthereumMachine, number: BlockNumber, proof: &[u8])
-		-> Result<(SimpleList, Option<H256>), ::error::Error>;
+		-> Result<(SimpleList, Option<H256>), Error>;
 
 	/// Checks if a given address is a validator, with the given function
 	/// for executing synchronous calls to contracts.
@@ -134,7 +135,15 @@ pub trait ValidatorSet: Send + Sync + 'static {
 	fn count_with_caller(&self, parent_block_hash: &H256, caller: &Call) -> usize;
 
 	/// Notifies about malicious behaviour.
-	fn report_malicious(&self, _validator: &Address, _set_block: BlockNumber, _block: BlockNumber, _signer: &mut dyn FnMut(H256) -> Signature) {}
+	fn report_malicious(
+		&self,
+		_validator: &Address,
+		_set_block: BlockNumber,
+		_block: BlockNumber,
+		_signer: &dyn Fn(H256) -> Result<Signature, Error>
+	) -> Result<(), Error> {
+		Ok(())
+	}
 	/// Notifies about benign misbehaviour.
 	fn report_benign(&self, _validator: &Address, _set_block: BlockNumber, _block: BlockNumber) {}
 	/// Allows blockchain state access.


### PR DESCRIPTION
- The `signer` argument of `report_malicious`:

  - The argument of `signer` is made immutable.

  - The result of `signer` now contains the `Error`.

- This `Error` is returned from the caller of `report_malicious` instead of being discarded in a call to `expect`.
