### PR TITLE
Flip `ConsensusKind::Poa` and `ConsensusKind::Pos` where needed

### DIFF
--- a/ethcore/src/engines/validator_set/mod.rs
+++ b/ethcore/src/engines/validator_set/mod.rs
@@ -45,10 +45,10 @@ use super::SystemCall;
 pub fn new_validator_set(spec: ValidatorSpec) -> Box<ValidatorSet> {
 	match spec {
 		ValidatorSpec::List(list) => Box::new(SimpleList::new(list.into_iter().map(Into::into).collect())),
-		ValidatorSpec::SafeContractCallGetPendingValidators(address) => Box::new(ValidatorSafeContract::new(address.into(), ConsensusKind::Poa)),
-		ValidatorSpec::SafeContract(address) => Box::new(ValidatorSafeContract::new(address.into(), ConsensusKind::Pos)),
-		ValidatorSpec::Contract(address) => Box::new(ValidatorContract::new(address.into(), ConsensusKind::Pos)),
-		ValidatorSpec::ContractCallGetPendingValidators(address) => Box::new(ValidatorContract::new(address.into(), ConsensusKind::Poa)),
+		ValidatorSpec::SafeContractCallGetPendingValidators(address) => Box::new(ValidatorSafeContract::new(address.into(), ConsensusKind::Pos)),
+		ValidatorSpec::SafeContract(address) => Box::new(ValidatorSafeContract::new(address.into(), ConsensusKind::Poa)),
+		ValidatorSpec::Contract(address) => Box::new(ValidatorContract::new(address.into(), ConsensusKind::Poa)),
+		ValidatorSpec::ContractCallGetPendingValidators(address) => Box::new(ValidatorContract::new(address.into(), ConsensusKind::Pos)),
 		ValidatorSpec::Multi(sequence) => Box::new(
 			Multi::new(sequence.into_iter().map(|(block, set)| (block.into(), new_validator_set(set))).collect())
 		),

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -334,8 +334,8 @@ impl ValidatorSet for ValidatorSafeContract {
 		}
 
 		let bloom = match self.consensus_kind {
-			ConsensusKind::Poa => None,
-			ConsensusKind::Pos => {
+			ConsensusKind::Pos => None,
+			ConsensusKind::Poa => {
 				let bloom = self.expected_bloom(header);
 				let header_bloom = header.log_bloom();
 				if &bloom & header_bloom != bloom { return ::engines::EpochChange::No }
@@ -396,8 +396,8 @@ impl ValidatorSet for ValidatorSafeContract {
 			}
 
 			match match self.consensus_kind {
-				ConsensusKind::Poa => self.extract_from_block(self.default_caller(BlockId::Number(number))),
-				ConsensusKind::Pos => self.extract_from_event(self.expected_bloom(&old_header), &old_header, &receipts),
+				ConsensusKind::Pos => self.extract_from_block(self.default_caller(BlockId::Number(number))),
+				ConsensusKind::Poa => self.extract_from_event(self.expected_bloom(&old_header), &old_header, &receipts),
 			} {
 				Some(list) => Ok((list, Some(old_header.hash()))),
 				None => Err(::engines::EngineError::InsufficientProof("No log event in proof.".into()).into()),


### PR DESCRIPTION
I had assumed that Proof of Stake (PoS) was the current consensus
algorithm and Proof of Authority (PoA) was the new one, but in reality,
the opposite is the case.