### PR TITLE
Use more informative error variants for FailedSystemCall

### DIFF
--- a/ethcore/src/engines/block_reward.rs
+++ b/ethcore/src/engines/block_reward.rs
@@ -130,7 +130,7 @@ impl BlockRewardContract {
 
 		let tokens = ethabi::decode(types, &output)
 			.map_err(|err| err.to_string())
-			.map_err(::engines::EngineError::FailedSystemCall)?;
+			.map_err(::engines::EngineError::SystemCallResultDecoding)?;
 
 		assert!(tokens.len() == 2);
 
@@ -138,7 +138,7 @@ impl BlockRewardContract {
 		let rewards = tokens[1].clone().to_array().expect("type checked by ethabi::decode; qed");
 
 		if addresses.len() != rewards.len() {
-			return Err(::engines::EngineError::FailedSystemCall(
+			return Err(::engines::EngineError::SystemCallResultInvalid(
 				"invalid data returned by reward contract: both arrays must have the same size".into()
 			).into());
 		}

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -88,6 +88,10 @@ pub enum EngineError {
 	InsufficientProof(String),
 	/// Failed system call.
 	FailedSystemCall(String),
+	/// Failed to decode the result of a system call.
+	SystemCallResultDecoding(String),
+	/// The result of a system call is invalid.
+	SystemCallResultInvalid(String),
 	/// Malformed consensus message.
 	MalformedMessage(String),
 	/// Requires client ref, but none registered.
@@ -105,6 +109,8 @@ impl fmt::Display for EngineError {
 			BadSealFieldSize(ref oob) => format!("Seal field has an unexpected length: {}", oob),
 			InsufficientProof(ref msg) => format!("Insufficient validation proof: {}", msg),
 			FailedSystemCall(ref msg) => format!("Failed to make system call: {}", msg),
+			SystemCallResultDecoding(ref msg) => format!("Failed to decode the result of a system call: {}", msg),
+			SystemCallResultInvalid(ref msg) => format!("The result of a system call is invalid: {}", msg),
 			MalformedMessage(ref msg) => format!("Received malformed consensus message: {}", msg),
 			RequiresClient => format!("Call requires client but none registered"),
 		};


### PR DESCRIPTION
`EngineError::FailedSystemCall` was used to denote 3 different kinds of error in `block_reward.rs`. This PR corrects that.