### PR TITLE
Fix randomness secret.

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -432,9 +432,8 @@ pub struct AuthorityRound {
 	strict_empty_steps_transition: u64,
 	maximum_empty_steps: usize,
 	machine: EthereumMachine,
-	/// The stored secret contribution to randomness.
-	// TODO: Only used in PoS. Maybe make part of `ConsensusKind`? Or tie together with `randomness_contract_address`?
-	rand_secret: RwLock<Option<randomness::Secret>>,
+	/// The stored secret contribution to randomness, and the collect round it belongs to.
+	rand_secret: RwLock<Option<(U256, randomness::Secret)>>,
 	/// If set, enables random number contract integration.
 	randomness_contract_address: Option<Address>,
 }

--- a/ethcore/src/engines/authority_round/util.rs
+++ b/ethcore/src/engines/authority_round/util.rs
@@ -95,7 +95,10 @@ impl<'a> BoundContract<'a> {
 			.as_full_client()
 			.ok_or(CallError::NotFullClient)?;
 
-		cl.transact(Action::Call(self.contract_addr), data, None, Some(U256::zero()))
-			.map_err(CallError::TransactionFailed)
+		// Don't return an error if the transaction is already in the queue.
+		match cl.transact(Action::Call(self.contract_addr), data, None, Some(U256::zero())) {
+			Err(transaction::Error::AlreadyImported) | Ok(()) => Ok(()),
+			Err(err) => Err(CallError::TransactionFailed(err)),
+		}
 	}
 }


### PR DESCRIPTION
`Engine::on_new_block` is called multiple times, so we need to
remember which round a random secret is for, and generate a new one
only in the following round. `on_block_new` also mustn't fail if
the same transaction is produced again.

Closes #67.