### PR TITLE
Add EngineError variants for randomness errors

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -51,6 +51,9 @@ mod finality;
 mod randomness;
 pub(crate) mod util;
 
+/// Export PhaseError from randomness to use in EngineError
+pub type RandomnessPhaseError = randomness::PhaseError;
+
 /// `AuthorityRound` params.
 pub struct AuthorityRoundParams {
 	/// Time to wait before next block or authority switching,
@@ -1158,10 +1161,10 @@ impl Engine<EthereumMachine> for AuthorityRound {
 			let accounts = self.signer.read().account_provider().clone();
 			// TODO: How should these errors be handled?
 			let phase = randomness::RandomnessPhase::load(&contract, our_addr)
-				.map_err(|err| EngineError::FailedSystemCall(format!("Randomness error: {:?}", err)))?;
+				.map_err(EngineError::RandomnessLoadError)?;
 			let mut rng = ::rand::OsRng::new()?;
 			phase.advance(&contract, &mut rng, &*accounts)
-				.map_err(|err| EngineError::FailedSystemCall(format!("Randomness error: {:?}", err)))?;
+				.map_err(EngineError::RandomnessAdvanceError)?;
 		}
 
 		// genesis is never a new block, but might as well check.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -29,7 +29,7 @@ mod vote_collector;
 pub mod block_reward;
 pub mod epoch;
 
-pub use self::authority_round::AuthorityRound;
+pub use self::authority_round::{AuthorityRound, RandomnessPhaseError};
 pub use self::basic_authority::BasicAuthority;
 pub use self::epoch::{EpochVerifier, Transition as EpochTransition};
 pub use self::instant_seal::{InstantSeal, InstantSealParams};
@@ -86,6 +86,10 @@ pub enum EngineError {
 	BadSealFieldSize(OutOfBounds<usize>),
 	/// Validation proof insufficient.
 	InsufficientProof(String),
+	/// Randomness error in load method
+	RandomnessLoadError(RandomnessPhaseError),
+	/// Randomness error in advance method
+	RandomnessAdvanceError(RandomnessPhaseError),
 	/// Failed system call.
 	FailedSystemCall(String),
 	/// Failed to decode the result of a system call.
@@ -108,6 +112,8 @@ impl fmt::Display for EngineError {
 			UnexpectedMessage => "This Engine should not be fed messages.".into(),
 			BadSealFieldSize(ref oob) => format!("Seal field has an unexpected length: {}", oob),
 			InsufficientProof(ref msg) => format!("Insufficient validation proof: {}", msg),
+			RandomnessLoadError(ref rerr) => format!("Randomness error in load(): {:?}", rerr),
+			RandomnessAdvanceError(ref rerr) => format!("Randomness error in advance(): {:?}", rerr),
 			FailedSystemCall(ref msg) => format!("Failed to make system call: {}", msg),
 			SystemCallResultDecoding(ref msg) => format!("Failed to decode the result of a system call: {}", msg),
 			SystemCallResultInvalid(ref msg) => format!("The result of a system call is invalid: {}", msg),


### PR DESCRIPTION
Cosmetic changes to introduce a dedicated `EngineError` variants for `PhaseError`s produced by `authority_round/randomness` module.

Can probably be handled better in the future.
