### PR TITLE
Add Engine::on_prepare_block, call randomness and validator set.

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -44,7 +44,7 @@ use itertools::{self, Itertools};
 use rlp::{encode, Decodable, DecoderError, Encodable, RlpStream, Rlp};
 use ethereum_types::{H256, H520, Address, U128, U256};
 use parking_lot::{Mutex, RwLock};
-use transaction::SignedTransaction;
+use transaction::{Action, SignedTransaction, Transaction};
 use types::ancestry_action::AncestryAction;
 use unexpected::{Mismatch, OutOfBounds};
 
@@ -1223,6 +1223,8 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		let header = block.header().clone();
 		let first = header.number() == 0;
 
+		let mut transactions = Vec::new();
+
 		// Random number generation
 		let client = match self.client.read().as_ref().and_then(|weak| weak.upgrade()) {
 			Some(client) => client,
@@ -1231,15 +1233,30 @@ impl Engine<EthereumMachine> for AuthorityRound {
 				return Err(EngineError::RequiresClient.into())
 			},
 		};
-		if let (Some(contract_addr), Some(our_addr)) = (self.randomness_contract_address, self.signer.read().address()) {
-			let block_id = BlockId::Latest;
-			let mut contract = util::BoundContract::bind(&*client, block_id, contract_addr);
+		if let (Some(contract_addr), Some(our_addr)) =
+				(self.randomness_contract_address, self.signer.read().address()) {
+			let mut contract = util::BoundContract::bind(&*client, BlockId::Latest, contract_addr);
 			let accounts = self.signer.read().account_provider().clone();
 			let phase = randomness::RandomnessPhase::load(&contract, our_addr)
 				.map_err(EngineError::RandomnessLoadError)?;
 			let mut rng = ::rand::OsRng::new()?;
-			phase.advance(&contract, &mut rng, &*accounts)
-				.map_err(EngineError::RandomnessAdvanceError)?;
+			if let Some(data) = phase.advance(&contract, &mut rng, &*accounts)
+					.map_err(EngineError::RandomnessAdvanceError)? {
+				// TODO: Find a better way to create these transactions.
+				let transaction = Transaction {
+					nonce: block.state.nonce(&our_addr).unwrap(), // TODO
+					action: Action::Call(contract_addr),
+					gas: U256::from(1000000),
+					gas_price: U256::zero(),
+					value: U256::zero(),
+					data,
+				};
+				let chain_id = Some(self.machine.params().chain_id); // TODO: See EIP155?
+				let signature = self.signer.read().sign(transaction.hash(chain_id))
+					.map_err(|e| transaction::Error::InvalidSignature(e.to_string())).unwrap(); // TODO
+				let signed_tx = SignedTransaction::new(transaction.with_signature(signature, chain_id)).unwrap();
+				transactions.push(signed_tx);
+			}
 		}
 
 		let mut call = |to, data| {
@@ -1247,9 +1264,9 @@ impl Engine<EthereumMachine> for AuthorityRound {
 			full_client.call_contract(BlockId::Latest, to, data).map_err(|e| format!("{}", e))
 		};
 
+		// TODO: Return new validator set transactions instead of putting them on the queue.
 		self.validators.on_new_block(first, &header, &mut call)?;
 
-		// TODO: Return new transactions instead of putting them on the queue.
 		Ok(Vec::new())
 	}
 

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -285,6 +285,12 @@ pub trait Engine<M: Machine>: Sync + Send {
 		Ok(())
 	}
 
+	/// Returns a list of transactions for a new block if we are the author.
+	///
+	/// This is called when the miner prepares a new block that this node will author and seal. It returns a list of
+	/// transactions that will be added to the block before any other transactions from the queue.
+	fn on_prepare_block(&self, _block: &M::LiveBlock) -> Result<Vec<SignedTransaction>, M::Error> { Ok(Vec::new()) }
+
 	/// None means that it requires external input (e.g. PoW) to seal a block.
 	/// Some(true) means the engine is currently prime for seal generation (i.e. node is the current validator).
 	/// Some(false) means that the node might seal internally but is not qualified now.


### PR DESCRIPTION
This adds an `Engine::on_prepare_block` method that is called from within the miner right after a new block for mining has been opened. The transactions it returns are put directly into the block, without going through the queue.

This change also moves the calls to the randomness and validator set contracts into `on_prepare_block`, but the latter still puts the transactions in the queue for now.

See #75.