### PR TITLE
Don't return transactions from Engine::on_prepare_block.

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -44,7 +44,6 @@ use itertools::{self, Itertools};
 use rlp::{encode, Decodable, DecoderError, Encodable, RlpStream, Rlp};
 use ethereum_types::{H256, H520, Address, U128, U256};
 use parking_lot::{Mutex, RwLock};
-use transaction::SignedTransaction;
 use types::ancestry_action::AncestryAction;
 use unexpected::{Mismatch, OutOfBounds};
 
@@ -1218,7 +1217,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 	}
 
 	/// Make calls to the randomness and validator set contracts.
-	fn on_prepare_block(&self, block: &ExecutedBlock) -> Result<Vec<SignedTransaction>, Error> {
+	fn on_prepare_block(&self, block: &ExecutedBlock) -> Result<(), Error> {
 		// Genesis is never a new block, but might as well check.
 		let header = block.header().clone();
 		let first = header.number() == 0;
@@ -1249,8 +1248,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 		self.validators.on_new_block(first, &header, &mut call)?;
 
-		// TODO: Return new transactions instead of putting them on the queue.
-		Ok(Vec::new())
+		Ok(())
 	}
 
 	/// Check the number of seal fields.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -287,9 +287,9 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Returns a list of transactions for a new block if we are the author.
 	///
-	/// This is called when the miner prepares a new block that this node will author and seal. It returns a list of
-	/// transactions that will be added to the block before any other transactions from the queue.
-	fn on_prepare_block(&self, _block: &M::LiveBlock) -> Result<Vec<SignedTransaction>, M::Error> { Ok(Vec::new()) }
+	/// This is called when the miner prepares a new block that this node will author and seal. It can queue
+	/// transactions before they are put into the block.
+	fn on_prepare_block(&self, _block: &M::LiveBlock) -> Result<(), M::Error> { Ok(()) }
 
 	/// None means that it requires external input (e.g. PoW) to seal a block.
 	/// Some(true) means the engine is currently prime for seal generation (i.e. node is the current validator).


### PR DESCRIPTION
We put the transactions in the queue instead.