### PR TITLE
Cleanup rand contract, improve error handling.

### DIFF
--- a/ethcore/res/contracts/authority_round_random.json
+++ b/ethcore/res/contracts/authority_round_random.json
@@ -25,18 +25,6 @@
 	{
 		"constant": false,
 		"inputs": [{
-			"name": "_secretHash",
-			"type": "bytes32"
-		}],
-		"name": "commitHash",
-		"outputs": [],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [{
 				"name": "_secretHash",
 				"type": "bytes32"
 			},

--- a/ethcore/src/engines/authority_round/util.rs
+++ b/ethcore/src/engines/authority_round/util.rs
@@ -96,8 +96,11 @@ impl<'a> BoundContract<'a> {
 			.ok_or(CallError::NotFullClient)?;
 
 		// Don't return an error if the transaction is already in the queue.
+		// TODO: Find out why we get `Old` errors. These seem to be about the transaction having an outdated nonce. But
+		// the nonce is set to `latest_nonce` inside `Client::transact`!
 		match cl.transact(Action::Call(self.contract_addr), data, None, Some(U256::zero())) {
 			Err(transaction::Error::AlreadyImported) | Ok(()) => Ok(()),
+			Err(err @ transaction::Error::Old) => Ok(error!(target: "engine", "Client::transact failed: {:?}", err)),
 			Err(err) => Err(CallError::TransactionFailed(err)),
 		}
 	}


### PR DESCRIPTION
The contract seems to have a duplicate entry. This replaces it
with the generated ABI.

`Client::transact` sometimes fails with and `Old` error, meaning
the nonce is outdated. This will now just log an error instead of
making block creation fail. The `schedule_service_transaction`
method might get removed in the future anyway, if we make
`ValidatorSet::on_new_block` _return_ the transaction instead of
queueing it.