### PR TITLE
Move transaction creation back into the client.

### DIFF
--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -859,20 +859,31 @@ impl BlockChainClient for TestBlockChainClient {
 		}
 	}
 
-	fn transact(&self, action: Action, data: Bytes, gas: Option<U256>, gas_price: Option<U256>)
-		-> Result<(), transaction::Error>
-	{
+	fn create_transaction(
+		&self,
+		action: Action,
+		data: Bytes,
+		gas: Option<U256>,
+		gas_price: Option<U256>,
+		nonce: Option<U256>
+	) -> Result<SignedTransaction, transaction::Error> {
 		let transaction = Transaction {
-			nonce: self.latest_nonce(&self.miner.authoring_params().author),
+			nonce: nonce.unwrap_or_else(|| self.latest_nonce(&self.miner.authoring_params().author)),
 			action,
 			gas: gas.unwrap_or(self.spec.gas_limit),
-			gas_price: gas_price.unwrap_or(U256::zero()),
+			gas_price: gas_price.unwrap_or_else(U256::zero),
 			value: U256::default(),
 			data: data,
 		};
 		let chain_id = Some(self.spec.chain_id());
 		let sig = self.spec.engine.sign(transaction.hash(chain_id)).unwrap();
-		let signed = SignedTransaction::new(transaction.with_signature(sig, chain_id)).unwrap();
+		Ok(SignedTransaction::new(transaction.with_signature(sig, chain_id)).unwrap())
+	}
+
+	fn transact(&self, action: Action, data: Bytes, gas: Option<U256>, gas_price: Option<U256>)
+		-> Result<(), transaction::Error>
+	{
+		let signed = self.create_transaction(action, data, gas, gas_price, None)?;
 		self.miner.import_own_transaction(self, signed.into())
 	}
 

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -392,6 +392,16 @@ pub trait BlockChainClient : Sync + Send + AccountData + BlockChain + CallContra
 		self.transact(Action::Call(address), data, None, None)
 	}
 
+	/// Returns a signed transaction. If gas limit, gas price, or nonce are not specified, the defaults are used.
+	fn create_transaction(
+		&self,
+		action: Action,
+		data: Bytes,
+		gas: Option<U256>,
+		gas_price: Option<U256>,
+		nonce: Option<U256>
+	) -> Result<SignedTransaction, transaction::Error>;
+
 	/// Schedule state-altering transaction to be executed on the next pending block with the given gas parameters.
 	///
 	/// If they are `None`, sensible values are selected automatically.

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -45,7 +45,7 @@ use itertools::{self, Itertools};
 use rlp::{encode, Decodable, DecoderError, Encodable, RlpStream, Rlp};
 use ethereum_types::{H256, H520, Address, U128, U256};
 use parking_lot::{Mutex, RwLock};
-use transaction::{Action, SignedTransaction, Transaction};
+use transaction::{Action, SignedTransaction};
 use types::ancestry_action::AncestryAction;
 use unexpected::{Mismatch, OutOfBounds};
 
@@ -1146,6 +1146,10 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		epoch_begin: bool,
 		_ancestry: &mut Iterator<Item=ExtendedHeader>,
 	) -> Result<(), Error> {
+		// with immediate transitions, we don't use the epoch mechanism anyway.
+		// the genesis is always considered an epoch, but we ignore it intentionally.
+		if self.immediate_transitions || !epoch_begin { return Ok(()) }
+
 		// genesis is never a new block, but might as well check.
 		let header = block.header().clone();
 		let first = header.number() == 0;
@@ -1160,10 +1164,6 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 			result.map_err(|e| format!("{}", e))
 		};
-
-		// with immediate transitions, we don't use the epoch mechanism anyway.
-		// the genesis is always considered an epoch, but we ignore it intentionally.
-		if self.immediate_transitions || !epoch_begin { return Ok(()) }
 
 		self.validators.on_epoch_begin(first, &header, &mut call)
 	}
@@ -1225,37 +1225,28 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		let first = header.number() == 0;
 
 		let our_addr = self.signer.read().address().ok_or_else(|| EngineError::NotAuthorized(*header.author()))?;
-		let chain_id = Some(self.machine.params().chain_id); // TODO: See EIP155?
-		let mut tx_nonce = block.state.nonce(&our_addr)?;
 
 		let client = self.client.read().as_ref().and_then(|weak| weak.upgrade()).ok_or_else(|| {
 			debug!(target: "engine", "Unable to prepare block: missing client ref.");
 			EngineError::RequiresClient
 		})?;
+		let full_client = client.as_full_client()
+			.ok_or(EngineError::FailedSystemCall("Failed to upgrade to BlockchainClient.".to_string()))?;
 
 		// Makes a constant contract call.
 		let mut call = |to: Address, data: Bytes| {
-			let full_client = client.as_full_client().ok_or("Failed to upgrade to BlockchainClient.".to_string())?;
 			full_client.call_contract(BlockId::Latest, to, data).map_err(|e| format!("{}", e))
 		};
 
+		// Our current account nonce. The transactions must have consecutive nonces, starting with this one.
+		let mut tx_nonce = block.state.nonce(&our_addr)?;
 		let mut transactions = Vec::new();
 
 		// Creates and signs a transaction with the given contract call.
 		let mut make_transaction = |to: Address, data: Bytes| -> Result<SignedTransaction, Error> {
-			let nonce = tx_nonce;
-			tx_nonce += U256::from(1);
-			let transaction = Transaction {
-				nonce,
-				action: Action::Call(to),
-				gas: U256::from(1_000_000),
-				gas_price: U256::zero(),
-				value: U256::zero(),
-				data,
-			};
-			let signature = self.signer.read().sign(transaction.hash(chain_id))
-				.map_err(|e| transaction::Error::InvalidSignature(e.to_string()))?;
-			Ok(SignedTransaction::new(transaction.with_signature(signature, chain_id))?)
+			let nonce = Some(tx_nonce);
+			tx_nonce += U256::one(); // Increment the nonce for the next transaction.
+			Ok(full_client.create_transaction(Action::Call(to), data, None, Some(U256::zero()), nonce)?)
 		};
 
 		// Random number generation


### PR DESCRIPTION
That solves the issue of the gas limit, where we'd otherwise pick
some arbitrary large value, and the chain ID, which now conforms
to EIP155 again.