### PR TITLE
Add SealingState; don't prepare block when not ready.

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -61,7 +61,7 @@ use client::{
 	IoClient, BadBlocks,
 };
 use client::bad_blocks;
-use engines::{EthEngine, EpochTransition, ForkChoice, EngineError};
+use engines::{EthEngine, EpochTransition, ForkChoice, EngineError, SealingState};
 use engines::epoch::PendingTransition;
 use error::{
 	ImportErrorKind, ExecutionError, CallError, BlockError,
@@ -2422,7 +2422,7 @@ impl ImportSealedBlock for Client {
 			&[],
 			route.enacted(),
 			route.retracted(),
-			self.engine.seals_internally().is_some(),
+			self.engine.sealing_state() != SealingState::External,
 		);
 		self.notify(|notify| {
 			notify.new_blocks(

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -27,7 +27,7 @@ use std::time::{UNIX_EPOCH, SystemTime, Duration};
 use block::*;
 use bytes::Bytes;
 use client::{BlockId, EngineClient};
-use engines::{Engine, Seal, EngineError, ConstructedVerifier};
+use engines::{Engine, Seal, SealingState, EngineError, ConstructedVerifier};
 use engines::block_reward;
 use engines::block_reward::{BlockRewardContract, RewardKind};
 use error::{Error, ErrorKind, BlockError};
@@ -229,9 +229,15 @@ impl EpochManager {
 		}
 	}
 
-	// zoom to epoch for given header. returns true if succeeded, false otherwise.
-	fn zoom_to(&mut self, client: &EngineClient, machine: &EthereumMachine, validators: &ValidatorSet, header: &Header) -> bool {
-		let last_was_parent = self.finality_checker.subchain_head() == Some(*header.parent_hash());
+	// Zooms to the epoch after the header with the given hash. Returns true if succeeded, false otherwise.
+	fn zoom_to_after(
+		&mut self,
+		client: &EngineClient,
+		machine: &EthereumMachine,
+		validators: &ValidatorSet,
+		hash: H256
+	) -> bool {
+		let last_was_parent = self.finality_checker.subchain_head() == Some(hash);
 
 		// early exit for current target == chain head, but only if the epochs are
 		// the same.
@@ -240,13 +246,13 @@ impl EpochManager {
 		}
 
 		self.force = false;
-		debug!(target: "engine", "Zooming to epoch for block {}", header.hash());
+		debug!(target: "engine", "Zooming to epoch after block {}", hash);
 
 		// epoch_transition_for can be an expensive call, but in the absence of
 		// forks it will only need to be called for the block directly after
 		// epoch transition, in which case it will be O(1) and require a single
 		// DB lookup.
-		let last_transition = match client.epoch_transition_for(*header.parent_hash()) {
+		let last_transition = match client.epoch_transition_for(hash) {
 			Some(t) => t,
 			None => {
 				// this really should never happen unless the block passed
@@ -732,7 +738,7 @@ impl AuthorityRound {
 				}
 			};
 
-			if !epoch_manager.zoom_to(&*client, &self.machine, &*self.validators, header) {
+			if !epoch_manager.zoom_to_after(&*client, &self.machine, &*self.validators, *header.parent_hash()) {
 				debug!(target: "engine", "Unable to zoom to epoch.");
 				return Err(EngineError::RequiresClient.into())
 			}
@@ -840,7 +846,7 @@ impl AuthorityRound {
 		};
 
 		let mut epoch_manager = self.epoch_manager.lock();
-		if !epoch_manager.zoom_to(&*client, &self.machine, &*self.validators, chain_head) {
+		if !epoch_manager.zoom_to_after(&*client, &self.machine, &*self.validators, *chain_head.parent_hash()) {
 			return Vec::new();
 		}
 
@@ -1007,9 +1013,50 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		header.set_difficulty(score);
 	}
 
-	fn seals_internally(&self) -> Option<bool> {
-		// TODO: accept a `&Call` here so we can query the validator set.
-		Some(self.signer.read().is_some())
+	fn sealing_state(&self) -> SealingState {
+		let opt_signer = self.signer.read();
+		let signer = match opt_signer.as_ref() {
+			Some(signer) => signer,
+			None => return SealingState::NotReady, // We are not a validator, so we shouldn't call the contracts.
+		};
+		let our_addr = signer.address();
+
+		let client = match self.client.read().as_ref().and_then(|weak| weak.upgrade()) {
+			Some(client) => client,
+			None => {
+				warn!(target: "engine", "Not preparing block: missing client ref.");
+				return SealingState::NotReady;
+			}
+		};
+
+		let parent = match client.as_full_client() {
+			Some(full_client) => full_client.best_block_header(),
+			None => {
+				debug!(target: "engine", "Not preparing block: not a full client.");
+				return SealingState::NotReady;
+			},
+		};
+
+		let validators = if self.immediate_transitions {
+			CowLike::Borrowed(&*self.validators)
+		} else {
+			let mut epoch_manager = self.epoch_manager.lock();
+			if !epoch_manager.zoom_to_after(&*client, &self.machine, &*self.validators, parent.hash()) {
+				debug!(target: "engine", "Not preparing block: Unable to zoom to epoch.");
+				return SealingState::NotReady;
+			}
+			CowLike::Owned(epoch_manager.validators().clone())
+		};
+
+		let step = self.step.inner.load();
+
+		if !is_step_proposer(&*validators, &parent.hash(), step, &our_addr) {
+			trace!(target: "engine", "Not preparing block: not a proposer for step {}. (Our address: {})",
+				   step, our_addr);
+			return SealingState::NotReady;
+		}
+
+		SealingState::Ready
 	}
 
 	fn handle_message(&self, rlp: &[u8]) -> Result<(), EngineError> {
@@ -1018,7 +1065,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		}
 
 		let rlp = Rlp::new(rlp);
-		let empty_step: EmptyStep = rlp.as_val().map_err(fmt_err)?;;
+		let empty_step: EmptyStep = rlp.as_val().map_err(fmt_err)?;
 
 		if empty_step.verify(&*self.validators).unwrap_or(false) {
 			if self.step.inner.check_future(empty_step.step).is_ok() {
@@ -1448,7 +1495,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 			};
 
 			let mut epoch_manager = self.epoch_manager.lock();
-			if !epoch_manager.zoom_to(&*client, &self.machine, &*self.validators, chain_head) {
+			if !epoch_manager.zoom_to_after(&*client, &self.machine, &*self.validators, *chain_head.parent_hash()) {
 				return None;
 			}
 

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -21,7 +21,7 @@ use ethereum_types::{H256, H520};
 use parking_lot::RwLock;
 use ethkey::{self, Signature};
 use block::*;
-use engines::{Engine, Seal, ConstructedVerifier, EngineError};
+use engines::{Engine, Seal, ConstructedVerifier, EngineError, SealingState};
 use engines::signer::EngineSigner;
 use error::{BlockError, Error};
 use ethjson;
@@ -98,8 +98,12 @@ impl Engine<EthereumMachine> for BasicAuthority {
 	// One field - the signature
 	fn seal_fields(&self, _header: &Header) -> usize { 1 }
 
-	fn seals_internally(&self) -> Option<bool> {
-		Some(self.signer.read().is_some())
+	fn sealing_state(&self) -> SealingState {
+		if self.signer.read().is_some() {
+			SealingState::Ready
+		} else {
+			SealingState::NotReady
+		}
 	}
 
 	/// Attempt to seal the block internally.
@@ -224,7 +228,7 @@ mod tests {
 	use accounts::AccountProvider;
 	use types::header::Header;
 	use spec::Spec;
-	use engines::Seal;
+	use engines::{Seal, SealingState};
 	use tempdir::TempDir;
 
 	/// Create a new test chain spec with `BasicAuthority` consensus engine.
@@ -276,15 +280,15 @@ mod tests {
 	}
 
 	#[test]
-	fn seals_internally() {
+	fn sealing_state() {
 		let tap = AccountProvider::transient_provider();
 		let authority = tap.insert_account(keccak("").into(), &"".into()).unwrap();
 
 		let engine = new_test_authority().engine;
-		assert!(!engine.seals_internally().unwrap());
+		assert_eq!(SealingState::NotReady, engine.sealing_state());
 		engine.set_signer(Box::new((Arc::new(tap), authority, "".into())));
-		assert!(engine.seals_internally().unwrap());
+		assert_eq!(SealingState::Ready, engine.sealing_state());
 		engine.clear_signer();
-		assert!(!engine.seals_internally().unwrap());
+		assert_eq!(SealingState::NotReady, engine.sealing_state());
 	}
 }

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use engines::{Engine, Seal};
+use engines::{Engine, Seal, SealingState};
 use parity_machine::{Machine, Transactions, TotalScoredHeader};
 
 /// `InstantSeal` params.
@@ -59,7 +59,7 @@ impl<M: Machine> Engine<M> for InstantSeal<M>
 
 	fn machine(&self) -> &M { &self.machine }
 
-	fn seals_internally(&self) -> Option<bool> { Some(true) }
+	fn sealing_state(&self) -> SealingState { SealingState::Ready }
 
 	fn generate_seal(&self, block: &M::LiveBlock, _parent: &M::Header) -> Seal {
 		if block.transactions().is_empty() { Seal::None } else { Seal::Regular(Vec::new()) }

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -134,6 +134,17 @@ pub enum Seal {
 	None,
 }
 
+/// The type of sealing the engine is currently able to perform.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SealingState {
+	/// The engine is ready to seal a block.
+	Ready,
+	/// The engine can't seal at the moment, and no block should be prepared and queued.
+	NotReady,
+	/// The engine does not seal internally.
+	External,
+}
+
 /// A system-calling closure. Enacts calls on a block's state from the system address.
 pub type SystemCall<'a> = FnMut(Address, Vec<u8>) -> Result<Vec<u8>, String> + 'a;
 
@@ -283,10 +294,8 @@ pub trait Engine<M: Machine>: Sync + Send {
 	/// transactions that will be added to the block before any other transactions from the queue.
 	fn on_prepare_block(&self, _block: &M::LiveBlock) -> Result<Vec<SignedTransaction>, M::Error> { Ok(Vec::new()) }
 
-	/// None means that it requires external input (e.g. PoW) to seal a block.
-	/// Some(true) means the engine is currently prime for seal generation (i.e. node is the current validator).
-	/// Some(false) means that the node might seal internally but is not qualified now.
-	fn seals_internally(&self) -> Option<bool> { None }
+	/// Returns the engine's current sealing state.
+	fn sealing_state(&self) -> SealingState { SealingState::External }
 
 	/// Attempt to seal the block internally.
 	///


### PR DESCRIPTION
This prevents the miner from creating new blocks for sealing even if it's not our turn to seal them.

However, it likely does not detect all cases yet where it's not our turn.

(Closes #70.)