### PR TITLE
Add ChainNotify::send.

### DIFF
--- a/ethcore/src/client/chain_notify.rs
+++ b/ethcore/src/client/chain_notify.rs
@@ -177,6 +177,11 @@ pub trait ChainNotify : Send + Sync {
 		// does nothing by default
 	}
 
+	/// fires when chain sends a message to a specific peer
+	fn send(&self, _message_type: ChainMessageType, _peer_id: usize) {
+		// does nothing by default
+	}
+
 	/// fires when new block is about to be imported
 	/// implementations should be light
 	fn block_pre_import(&self, _bytes: &Bytes, _hash: &H256, _difficulty: &U256) {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2415,8 +2415,8 @@ impl super::traits::EngineClient for Client {
 		self.notify(|notify| notify.broadcast(ChainMessageType::Consensus(message.clone())));
 	}
 
-	fn send_consensus_message(&self, _message: Bytes, _peer_id: usize) {
-		// TODO: send to the specified peer only
+	fn send_consensus_message(&self, message: Bytes, peer_id: usize) {
+		self.notify(|notify| notify.send(ChainMessageType::Consensus(message.clone()), peer_id));
 	}
 
 	fn epoch_transition_for(&self, parent_hash: H256) -> Option<::engines::EpochTransition> {

--- a/ethcore/src/test_helpers.rs
+++ b/ethcore/src/test_helpers.rs
@@ -504,6 +504,8 @@ pub fn get_bad_state_dummy_block() -> Bytes {
 pub struct TestNotify {
 	/// Messages store
 	pub messages: RwLock<Vec<Bytes>>,
+	/// Targeted messages store
+	pub targeted_messages: RwLock<Vec<(Bytes, usize)>>,
 }
 
 impl ChainNotify for TestNotify {
@@ -514,5 +516,14 @@ impl ChainNotify for TestNotify {
 			ChainMessageType::PrivateTransaction(_, data) => data,
 		};
 		self.messages.write().push(data);
+	}
+
+	fn send(&self, message: ChainMessageType, peer_id: usize) {
+		let data = match message {
+			ChainMessageType::Consensus(data) => data,
+			ChainMessageType::SignedPrivateTransaction(_, data) => data,
+			ChainMessageType::PrivateTransaction(_, data) => data,
+		};
+		self.targeted_messages.write().push((data, peer_id));
 	}
 }

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -583,6 +583,10 @@ impl ChainNotify for EthSync {
 		});
 	}
 
+	fn send(&self, _message_type: ChainMessageType, _peer_id: usize) {
+		unimplemented!("TODO: Send message to _peer_id.");
+	}
+
 	fn transactions_received(&self, txs: &[UnverifiedTransaction], peer_id: PeerId) {
 		let mut sync = self.eth_handler.sync.write();
 		sync.transactions_received(txs, peer_id);


### PR DESCRIPTION
In contrast to `ChainNotify::broadcast`, this is meant to send a message to a specific peer.