### PR TITLE
Notifying Parity Consensus Engines about Transaction Queue changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ name = "hbbft_engine"
 version = "0.0.1"
 dependencies = [
  "ethcore 1.12.0",
+ "ethcore-miner 1.12.0",
  "ethcore-transaction 0.1.0",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -20,6 +20,7 @@ keccak-hash = "0.1"
 ethcore = { path = ".." }
 ethereum-types = "0.4"
 ethcore-transaction = { path = "../transaction" }
+ethcore-miner = { path = "../../miner" }
 hbbft = { git = "https://github.com/poanetwork/hbbft" }
 ethkey = { path = "../../ethkey" }
 

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -8,6 +8,7 @@ use ethcore::engines::{total_difficulty_fork_choice, Engine, EthEngine, ForkChoi
 use ethcore::error::Error;
 use ethcore::header::{ExtendedHeader, Header};
 use ethcore::machine::EthereumMachine;
+use ethcore_miner::pool::TransactionQueue;
 use transaction::SignedTransaction;
 
 pub struct HoneyBadgerBFT {
@@ -52,6 +53,8 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 	fn seals_internally(&self) -> Option<bool> {
 		Some(true)
 	}
+
+	fn on_transactions_imported(&self, _queue: &Arc<TransactionQueue>) {}
 
 	fn on_prepare_block(&self, _block: &ExecutedBlock) -> Result<Vec<SignedTransaction>, Error> {
 		// TODO: inject random number transactions

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -8,7 +8,6 @@ use ethcore::engines::{total_difficulty_fork_choice, Engine, EthEngine, ForkChoi
 use ethcore::error::Error;
 use ethcore::header::{ExtendedHeader, Header};
 use ethcore::machine::EthereumMachine;
-use ethcore_miner::pool::TransactionQueue;
 use transaction::SignedTransaction;
 
 pub struct HoneyBadgerBFT {
@@ -54,7 +53,7 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 		Some(true)
 	}
 
-	fn on_transactions_imported(&self, _queue: &Arc<TransactionQueue>) {}
+	fn on_transactions_imported(&self) {}
 
 	fn on_prepare_block(&self, _block: &ExecutedBlock) -> Result<Vec<SignedTransaction>, Error> {
 		// TODO: inject random number transactions

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate ethcore;
 extern crate ethcore_transaction as transaction;
+extern crate ethcore_miner;
 extern crate ethereum_types;
 extern crate ethkey;
 extern crate inventory;

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -25,22 +25,9 @@ pub fn init() {
 
 #[cfg(test)]
 mod tests {
-	use std::sync::Arc;
-
 	use ethcore::client::{BlockId, BlockInfo};
 
 	use crate::test_helpers::{hbbft_client_setup, inject_transaction};
-
-	#[test]
-	fn test_client_miner_engine() {
-		super::init();
-
-		let (client, _, _) = hbbft_client_setup();
-
-		// Get hbbft Engine reference and initialize it with a back-reference to the Client
-		let engine = client.engine();
-		engine.register_client(Arc::downgrade(&client) as _);
-	}
 
 	#[test]
 	fn test_miner_transaction_injection() {

--- a/ethcore/hbbft_engine/src/test_helpers.rs
+++ b/ethcore/hbbft_engine/src/test_helpers.rs
@@ -27,6 +27,12 @@ pub fn hbbft_client_setup() -> (Arc<Client>, Arc<TestNotify>, Arc<Miner>) {
 	// Create client
 	let client = hbbft_client();
 
+	// Get hbbft Engine reference and initialize it with a back-reference to the Client
+	{
+		let engine = client.engine();
+		engine.register_client(Arc::downgrade(&client) as _);
+	}
+
 	// Register notify object for capturing consensus messages
 	let notify = Arc::new(TestNotify::default());
 	client.add_notify(notify.clone());

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2433,6 +2433,10 @@ impl super::traits::EngineClient for Client {
 	fn block_header(&self, id: BlockId) -> Option<::encoded::Header> {
 		BlockChainClient::block_header(self, id)
 	}
+
+	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
+		self.importer.miner.queued_transactions()
+	}
 }
 
 impl ProvingBlockChainClient for Client {

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -955,4 +955,8 @@ impl super::traits::EngineClient for TestBlockChainClient {
 	fn block_header(&self, id: BlockId) -> Option<::encoded::Header> {
 		BlockChainClient::block_header(self, id)
 	}
+
+	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
+		self.miner.queued_transactions()
+	}
 }

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -481,6 +481,9 @@ pub trait EngineClient: Sync + Send + ChainInfo {
 
 	/// Get raw block header data by block id.
 	fn block_header(&self, id: BlockId) -> Option<encoded::Header>;
+
+	/// Get up to n currently pending transactions
+	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>>;
 }
 
 /// Extended client interface for providing proofs of the state.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -53,6 +53,7 @@ use spec::CommonParams;
 use transaction::{self, UnverifiedTransaction, SignedTransaction};
 
 use ethkey::{Password, Signature};
+use ethcore_miner::pool::TransactionQueue;
 use parity_machine::{Machine, LocalizedMachine as Localized, TotalScoredHeader};
 use ethereum_types::{H256, U256, Address};
 use unexpected::{Mismatch, OutOfBounds};
@@ -269,6 +270,9 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Optional maximum gas limit.
 	fn maximum_gas_limit(&self) -> Option<U256> { None }
+
+	/// New transactions were imported to the transaction queue
+	fn on_transactions_imported(&self, _queue: &Arc<TransactionQueue>) {}
 
 	/// Block transformation functions, before the transactions.
 	/// `epoch_begin` set to true if this block kicks off an epoch.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -53,7 +53,6 @@ use spec::CommonParams;
 use transaction::{self, UnverifiedTransaction, SignedTransaction};
 
 use ethkey::{Password, Signature};
-use ethcore_miner::pool::TransactionQueue;
 use parity_machine::{Machine, LocalizedMachine as Localized, TotalScoredHeader};
 use ethereum_types::{H256, U256, Address};
 use unexpected::{Mismatch, OutOfBounds};
@@ -272,7 +271,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 	fn maximum_gas_limit(&self) -> Option<U256> { None }
 
 	/// New transactions were imported to the transaction queue
-	fn on_transactions_imported(&self, _queue: &Arc<TransactionQueue>) {}
+	fn on_transactions_imported(&self) {}
 
 	/// Block transformation functions, before the transactions.
 	/// `epoch_begin` set to true if this block kicks off an epoch.

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -252,7 +252,7 @@ impl Miner {
 		let tx_queue_strategy = options.tx_queue_strategy;
 		let nonce_cache_size = cmp::max(4096, limits.max_count / 4);
 
-		Miner {
+		let miner = Miner {
 			sealing: Mutex::new(SealingWork {
 				queue: UsingQueue::new(options.work_queue_size),
 				enabled: options.force_sealing
@@ -271,7 +271,16 @@ impl Miner {
 			accounts,
 			engine: spec.engine.clone(),
 			io_channel: RwLock::new(None),
-		}
+		};
+
+		// Notify engine about transaction queue changes
+		let engine = spec.engine.clone();
+		let transaction_queue = miner.transaction_queue.clone();
+		miner.add_transactions_listener(Box::new(move |_hashes| {
+			engine.on_transactions_imported(&transaction_queue);
+		}));
+
+		miner
 	}
 
 	/// Creates new instance of miner with given spec and accounts.

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -275,9 +275,8 @@ impl Miner {
 
 		// Notify engine about transaction queue changes
 		let engine = spec.engine.clone();
-		let transaction_queue = miner.transaction_queue.clone();
 		miner.add_transactions_listener(Box::new(move |_hashes| {
-			engine.on_transactions_imported(&transaction_queue);
+			engine.on_transactions_imported();
 		}));
 
 		miner

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -252,7 +252,7 @@ impl Miner {
 		let tx_queue_strategy = options.tx_queue_strategy;
 		let nonce_cache_size = cmp::max(4096, limits.max_count / 4);
 
-		let miner = Miner {
+		Miner {
 			sealing: Mutex::new(SealingWork {
 				queue: UsingQueue::new(options.work_queue_size),
 				enabled: options.force_sealing
@@ -271,15 +271,7 @@ impl Miner {
 			accounts,
 			engine: spec.engine.clone(),
 			io_channel: RwLock::new(None),
-		};
-
-		// Notify engine about transaction queue changes
-		let engine = spec.engine.clone();
-		miner.add_transactions_listener(Box::new(move |_hashes| {
-			engine.on_transactions_imported();
-		}));
-
-		miner
+		}
 	}
 
 	/// Creates new instance of miner with given spec and accounts.
@@ -905,8 +897,11 @@ impl miner::MinerService for Miner {
 		// | NOTE Code below requires sealing locks.                                |
 		// | Make sure to release the locks before calling that method.             |
 		// --------------------------------------------------------------------------
-		if !results.is_empty() && self.options.reseal_on_external_tx &&	self.sealing.lock().reseal_allowed() {
-			self.prepare_and_update_sealing(chain);
+		if !results.is_empty() {
+			self.engine.on_transactions_imported();
+			if self.options.reseal_on_external_tx && self.sealing.lock().reseal_allowed() {
+				self.prepare_and_update_sealing(chain);
+			}
 		}
 
 		results
@@ -931,8 +926,11 @@ impl miner::MinerService for Miner {
 		// | NOTE Code below requires sealing locks.                                |
 		// | Make sure to release the locks before calling that method.             |
 		// --------------------------------------------------------------------------
-		if imported.is_ok() && self.options.reseal_on_own_tx && self.sealing.lock().reseal_allowed() {
-			self.prepare_and_update_sealing(chain);
+		if imported.is_ok() {
+			self.engine.on_transactions_imported();
+			if self.options.reseal_on_own_tx && self.sealing.lock().reseal_allowed() {
+				self.prepare_and_update_sealing(chain);
+			}
 		}
 
 		imported


### PR DESCRIPTION
Added a "on_transactions_imported()" function to the Consensus Engine trait, called after successful import of new transactions.

Also added a "queued_transactions()" function to the EngineClient trait to query queued transactions.

Using "queued_transactions()" to trigger the creation of a new block when the transaction queue length trigger is reached (currently set to 1)

Registering the Client instance with the hbbft Consensus Engine in test helpers to be able to access EngineClient functions.