### PR TITLE
Configurable step duration transitions

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1992,6 +1992,7 @@ mod tests {
 			calibrate: false,
 			inner: AtomicUsize::new(::std::usize::MAX),
 			duration: AtomicU16::new(1),
+			next_duration: AtomicU16::new(1),
 		};
 		step.increment();
 	}
@@ -2006,6 +2007,7 @@ mod tests {
 			calibrate: false,
 			inner: AtomicUsize::new(::std::usize::MAX),
 			duration: AtomicU16::new(1),
+			next_duration: AtomicU16::new(1),
 		};
 		step.duration_remaining();
 	}

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1983,10 +1983,13 @@ mod tests {
 	#[should_panic(expected="counter is too high")]
 	fn test_counter_duration_remaining_too_high() {
 		use super::Step;
+		use std::sync::atomic::AtomicU16;
+
 		let step = Step {
 			calibrate: false,
 			inner: AtomicUsize::new(::std::usize::MAX),
-			duration: 1,
+			duration: AtomicU16::new(1),
+			next_duration: AtomicU16::new(1),
 		};
 		step.duration_remaining();
 	}

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -66,7 +66,7 @@ pub struct AuthorityRoundParams {
 	///
 	/// Deliberately typed as u16 as too high of a value leads
 	/// to slow block issuance.
-	pub step_duration: u16,
+	pub step_duration: BTreeMap<u64, u16>,
 	/// Starting step,
 	pub start_step: Option<u64>,
 	/// Valid validators.
@@ -126,6 +126,7 @@ impl From<ethjson::spec::AuthorityRoundParams> for AuthorityRoundParams {
 			maximum_empty_steps: p.maximum_empty_steps.map_or(0, Into::into),
 			strict_empty_steps_transition: p.strict_empty_steps_transition.map_or(0, Into::into),
 			randomness_contract_address: p.randomness_contract_address.map(Into::into),
+			step_duration_transition: p.step_duration_transition.map(|(d, n)| (Into::into(d), Into::into(n))),
 		}
 	}
 }

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -208,7 +208,7 @@ impl Step {
 			self.starting_sec.store(starting_sec, AtomicOrdering::SeqCst);
 			self.starting_step.store(next_step, AtomicOrdering::SeqCst);
 			self.inner.store(next_step, AtomicOrdering::SeqCst);
-			trace!(target: "engine", "Step duration updated at step {}", next_step);
+			trace!(target: "engine", "Step duration updated to {} at step {}", next_dur, next_step);
 		}
 	}
 
@@ -724,18 +724,17 @@ impl AuthorityRound {
 			panic!("authority_round: step duration cannot be 0");
 		}
 		let should_timeout = our_params.start_step.is_none();
-		let initial_step = our_params.start_step.unwrap_or_else(|| (unix_now().as_secs() / (duration as u64)));
 		let engine = Arc::new(
 			AuthorityRound {
 				transition_service: IoService::<()>::start()?,
 				step: Arc::new(PermissionedStep {
 					inner: Step {
-						inner: AtomicU64::new(initial_step),
+						inner: AtomicU64::new(0),
 						calibrate: our_params.start_step.is_none(),
                         current_duration: AtomicU16::new(duration),
 						durations: our_params.step_durations.clone(),
 						starting_sec: AtomicU64::new(unix_now().as_secs()),
-						starting_step: AtomicU64::new(initial_step),
+						starting_step: AtomicU64::new(0),
 					},
 					can_propose: AtomicBool::new(true),
 				}),

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -2001,7 +2001,7 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected="authority_round: step duration can't be zero")]
+	#[should_panic(expected="authority_round: step duration cannot be 0")]
 	fn test_step_duration_zero() {
 		aura(|params| {
 			params.step_duration = [(0, 0)].to_vec().into_iter().collect();;

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -105,7 +105,7 @@ impl From<ethjson::spec::AuthorityRoundParams> for AuthorityRoundParams {
 		let map_step_duration = |u: ethjson::uint::Uint| {
 			let mut step_duration_usize: usize = u.into();
 			if step_duration_usize == 0 {
-				panic!("step duration cannot be 0");
+				panic!("AuthorityRoundParams: step duration cannot be 0");
 			}
 			if step_duration_usize > U16_MAX {
 				step_duration_usize = U16_MAX;
@@ -696,6 +696,9 @@ impl AuthorityRound {
 			error!(target: "engine", "Authority Round step 0 duration is undefined, aborting");
 			panic!("authority_round: step 0 duration is undefined")
 		});
+		if our_params.step_duration.values().any(|v| *v == 0) {
+			panic!("authority_round: step duration cannot be 0");
+		}
 		let should_timeout = our_params.start_step.is_none();
 		let initial_step = our_params.start_step.unwrap_or_else(|| (unix_now().as_secs() / (duration as u64)));
 		let engine = Arc::new(

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -104,9 +104,12 @@ impl From<ethjson::spec::AuthorityRoundParams> for AuthorityRoundParams {
 	fn from(p: ethjson::spec::AuthorityRoundParams) -> Self {
 		let map_step_duration = |u: ethjson::uint::Uint| {
 			let mut step_duration_usize: usize = u.into();
+			if step_duration_usize == 0 {
+				panic!("step duration cannot be 0");
+			}
 			if step_duration_usize > U16_MAX {
 				step_duration_usize = U16_MAX;
-				warn!(target: "engine", "step_duration is too high ({}), setting it to {}", step_duration_usize, U16_MAX);
+				warn!(target: "engine", "step duration is too high ({}), setting it to {}", step_duration_usize, U16_MAX);
 			}
 			step_duration_usize as u16
 		};

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -2022,6 +2022,8 @@ mod tests {
 			inner: AtomicUsize::new(::std::usize::MAX),
 			duration: AtomicU16::new(1),
 			next_duration: AtomicU16::new(1),
+			starting_sec: AtomicUsize::new(::std::usize::MAX),
+			starting_step: AtomicUsize::new(::std::usize::MAX),
 		};
 		step.increment();
 	}
@@ -2037,6 +2039,8 @@ mod tests {
 			inner: AtomicUsize::new(::std::usize::MAX),
 			duration: AtomicU16::new(1),
 			next_duration: AtomicU16::new(1),
+			starting_sec: AtomicUsize::new(::std::usize::MAX),
+			starting_step: AtomicUsize::new(::std::usize::MAX),
 		};
 		step.duration_remaining();
 	}

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -19,7 +19,7 @@
 use hash::Address;
 use uint::Uint;
 use bytes::Bytes;
-use super::ValidatorSet;
+use super::{StepDuration, ValidatorSet};
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -34,7 +34,7 @@ pub enum ConsensusKind {
 #[serde(rename_all = "camelCase")]
 pub struct AuthorityRoundParams {
 	/// Block duration, in seconds.
-	pub step_duration: Uint,
+	pub step_duration: StepDuration,
 	/// Valid authorities
 	pub validators: ValidatorSet,
 	/// Starting step. Determined automatically if not specified.
@@ -69,6 +69,9 @@ pub struct AuthorityRoundParams {
 	/// Stake (PoS) consensus.  Otherwise, use Proof of Authority (PoA)
 	/// consensus.
 	pub randomness_contract_address: Option<Address>,
+	/// Optional instructions to change the block duration starting from a particular block given
+	/// as a pair `(duration, block_number)`.
+	pub step_duration_transition: Option<(Uint, Uint)>
 }
 
 /// Authority engine deserialization.
@@ -87,6 +90,7 @@ mod tests {
 	use hash::Address;
 	use spec::validator_set::ValidatorSet;
 	use spec::authority_round::AuthorityRound;
+	use spec::step_duration::StepDuration;
 
 	#[test]
 	fn authority_round_deserialization() {
@@ -105,12 +109,11 @@ mod tests {
 		}"#;
 
 		let deserialized: AuthorityRound = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized.params.step_duration, Uint(U256::from(0x02)));
+		assert_eq!(deserialized.params.step_duration, StepDuration::Single(Uint(U256::from(2))));
 		assert_eq!(deserialized.params.validators, ValidatorSet::List(vec![Address(H160::from("0xc6d9d2cd449a754c494264e1809c50e34d64562b"))]));
 		assert_eq!(deserialized.params.start_step, Some(Uint(U256::from(24))));
 		assert_eq!(deserialized.params.immediate_transitions, None);
 		assert_eq!(deserialized.params.maximum_uncle_count_transition, Some(Uint(10_000_000.into())));
 		assert_eq!(deserialized.params.maximum_uncle_count, Some(Uint(5.into())));
-
 	}
 }

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -69,9 +69,6 @@ pub struct AuthorityRoundParams {
 	/// Stake (PoS) consensus.  Otherwise, use Proof of Authority (PoA)
 	/// consensus.
 	pub randomness_contract_address: Option<Address>,
-	/// Optional instructions to change the block duration starting from a particular block given
-	/// as a pair `(duration, block_number)`.
-	pub step_duration_transition: Option<(Uint, Uint)>
 }
 
 /// Authority engine deserialization.

--- a/json/src/spec/mod.rs
+++ b/json/src/spec/mod.rs
@@ -31,6 +31,7 @@ pub mod authority_round;
 pub mod null_engine;
 pub mod instant_seal;
 pub mod hardcoded_sync;
+pub mod step_duration;
 
 pub use self::account::Account;
 pub use self::builtin::{Builtin, Pricing, Linear};
@@ -47,3 +48,4 @@ pub use self::authority_round::{AuthorityRound, AuthorityRoundParams};
 pub use self::null_engine::{NullEngine, NullEngineParams};
 pub use self::instant_seal::{InstantSeal, InstantSealParams};
 pub use self::hardcoded_sync::HardcodedSync;
+pub use self::step_duration::StepDuration;

--- a/json/src/spec/step_duration.rs
+++ b/json/src/spec/step_duration.rs
@@ -1,0 +1,33 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Step duration configuration parameter
+
+use std::collections::BTreeMap;
+use uint::Uint;
+
+/// Step duration can be specified either as a `Uint` (in seconds), in which case it will be
+/// constant, or as a list of pairs consisting of a block number and a duration, in which case the
+/// duration of a step will be determined by a mapping arising from that list.
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum StepDuration {
+	/// Duration of all steps.
+	Single(Uint),
+	/// Step duration transitions: a mapping of starting block numbers to step durations.
+	Transitions(BTreeMap<Uint, Uint>),
+}


### PR DESCRIPTION
Fixes #122.

The PR adds a configuration map and at the same time keeps the previous configuration option for backwards compatibility.

I'll rebase it on top of the rebased `aura-pos` as soon as we update the working branch.