### PR TITLE
Engine creates Block with chosen Transactions

### DIFF
--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -60,7 +60,8 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 		if let Some(ref weak) = *self.client.read() {
 			if let Some(c) = weak.upgrade() {
 				if c.queued_transactions().len() >= self.transactions_trigger {
-					c.update_sealing();
+					// TODO: Use the average timestamp of all contributing hbbft nodes
+					c.create_pending_block(c.queued_transactions(), 0);
 				}
 			}
 		}
@@ -74,5 +75,9 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 	fn generate_seal(&self, _block: &ExecutedBlock, _parent: &Header) -> Seal {
 		// For refactoring/debugging of block creation we seal instantly.
 		Seal::Regular(Vec::new())
+	}
+
+	fn should_miner_prepare_blocks(&self) -> bool {
+		false
 	}
 }

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2504,6 +2504,10 @@ impl super::traits::EngineClient for Client {
 	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
 		self.importer.miner.queued_transactions()
 	}
+
+	fn create_pending_block(&self, txns: Vec<Arc<VerifiedTransaction>>, timestamp: u64) -> Option<ClosedBlock> {
+		self.importer.miner.create_pending_block(self, txns, timestamp)
+	}
 }
 
 impl ProvingBlockChainClient for Client {

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -975,4 +975,8 @@ impl super::traits::EngineClient for TestBlockChainClient {
 	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
 		self.miner.queued_transactions()
 	}
+
+	fn create_pending_block(&self, txns: Vec<Arc<VerifiedTransaction>>, timestamp: u64) -> Option<ClosedBlock> {
+		self.miner.create_pending_block(self, txns, timestamp)
+	}
 }

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -472,6 +472,9 @@ pub trait EngineClient: Sync + Send + ChainInfo {
 
 	/// Get currently pending transactions
 	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>>;
+
+	/// Create block and queue it for sealing. Will return None if a block is already pending.
+ 	fn create_pending_block(&self, txns: Vec<Arc<VerifiedTransaction>>, timestamp: u64) -> Option<ClosedBlock>;
 }
 
 /// Extended client interface for providing proofs of the state.

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1745,7 +1745,7 @@ mod tests {
 		// Not a signer. A seal cannot be generated.
 		assert!(engine.generate_seal(b1.block(), &genesis_header) == Seal::None);
 		// Become a signer.
-		engine.set_signer(tap.clone(), addr1, "1".into());
+		engine.set_signer(Box::new((tap.clone(), addr1, "1".into())));
 		if let Seal::Regular(seal) = engine.generate_seal(b1.block(), &genesis_header) {
 			assert!(b1.clone().try_seal(engine, seal).is_ok());
 			// Second proposal is forbidden.
@@ -1770,7 +1770,7 @@ mod tests {
 		// Not a signer. A seal cannot be generated.
 		assert!(engine.generate_seal(b2.block(), &header2) == Seal::None);
 		// Become a signer once more.
-		engine.set_signer(tap, addr2, "0".into());
+		engine.set_signer(Box::new((tap, addr2, "0".into())));
 		if let Seal::Regular(seal) = engine.generate_seal(b2.block(), &header2) {
 			assert!(b2.clone().try_seal(engine, seal).is_ok());
 			// Second proposal is forbidden.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -253,6 +253,9 @@ pub trait Engine<M: Machine>: Sync + Send {
 	/// Additional engine-specific information for the user/developer concerning `header`.
 	fn extra_info(&self, _header: &M::Header) -> BTreeMap<String, String> { BTreeMap::new() }
 
+	/// Whether the miner should prepare blocks for sealing for this engine.
+	fn should_miner_prepare_blocks(&self) -> bool { true }
+
 	/// Maximum number of uncles a block is allowed to declare.
 	fn maximum_uncle_count(&self, _block: BlockNumber) -> usize { 0 }
 


### PR DESCRIPTION
Added create_pending_block() function to the EngineClient trait and implemented the function in Miner.
Using this function in the hbbft Engine implementation when the threshold number of queued Transactions is reached.

(Re)added the should_miner_prepare_blocks() function to the Engine trait. Used it to make "prepare_block" only return pending blocks or None if no pending blocks are available in the case of should_miner_prepare_blocks() returning false.