### PR TITLE
Environment for initializing hbbft algorithms in the HoneyBadgerBFT Parity consensus engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "evm 0.1.0",
  "fetch 0.1.0",
  "hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)",
  "heapsize 0.4.2 (git+https://github.com/cheme/heapsize.git?branch=ec-macfix)",
  "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,7 @@ dependencies = [
  "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "fastmap 0.1.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)",
  "heapsize 0.4.2 (git+https://github.com/cheme/heapsize.git?branch=ec-macfix)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,8 +142,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1644,7 +1657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hbbft"
 version = "0.1.1"
-source = "git+https://github.com/poanetwork/hbbft#a64f62506d1c3e98ad805c61f2c825439d2025d3"
+source = "git+https://github.com/poanetwork/hbbft.git#15f731370686f5456425c2e319225bf3b4d447c0"
 dependencies = [
  "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1672,13 +1685,29 @@ dependencies = [
  "ethcore-miner 1.12.0",
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
- "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft)",
+ "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)",
+ "hbbft_testing 0.1.0 (git+https://github.com/poanetwork/hbbft.git)",
  "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hbbft_testing"
+version = "0.1.0"
+source = "git+https://github.com/poanetwork/hbbft.git#15f731370686f5456425c2e319225bf3b4d447c0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)",
+ "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1862,6 +1891,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "integer-encoding"
 version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3254,6 +3288,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "protobuf"
 version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,7 +3409,7 @@ dependencies = [
  "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3466,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3710,6 +3763,17 @@ dependencies = [
  "sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3957,6 +4021,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4586,6 +4663,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4772,7 +4857,9 @@ dependencies = [
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "959c8e54c1ad412ffeeb95f05a9cade02d2d40a7b3c2f852d3353148f4beff35"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
+"checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+"checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -4858,7 +4945,8 @@ dependencies = [
 "checksum hamming 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b03501f6e1a2a97f1618879aba3156f14ca2847faa530c4e28859638bd11483"
-"checksum hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft)" = "<none>"
+"checksum hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)" = "<none>"
+"checksum hbbft_testing 0.1.0 (git+https://github.com/poanetwork/hbbft.git)" = "<none>"
 "checksum heapsize 0.4.2 (git+https://github.com/cheme/heapsize.git?branch=ec-macfix)" = "<none>"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
@@ -4877,6 +4965,7 @@ dependencies = [
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum init_with 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0175f63815ce00183bf755155ad0cb48c65226c5d17a724e369c25418d2b7699"
 "checksum integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26746cbc2e680af687e88d717f20ff90079bd10fc984ad57d277cd0e37309fa5"
+"checksum integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ea155abb3ba6f382a75f1418988c05fe82959ed9ce727de427f9cfd425b0c903"
 "checksum interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
 "checksum inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21df85981fe094480bc2267723d3dc0fd1ae0d1f136affc659b7398be615d922"
 "checksum inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a877ae8bce77402d5e9ed870730939e097aad827b2a932b361958fa9d6e75aa"
@@ -4985,6 +5074,7 @@ dependencies = [
 "checksum primal-estimate 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "56ea4531dde757b56906493c8604641da14607bf9cdaa80fb9c9cabd2429f8d5"
 "checksum primal-sieve 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "da2d6ed369bb4b0273aeeb43f07c105c0117717cbae827b20719438eb2eb798c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24f5844db2f839e97e3021980975f6ebf8691d9b9b2ca67ed3feb38dc3edb52c"
 "checksum protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "52fbc45bf6709565e44ef31847eb7407b3c3c80af811ee884a04da071dcca12b"
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
 "checksum pwasm-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e9135bed7b452e20dbb395a2d519abaf0c46d60e7ecc02daeeab447d29bada1"
@@ -5007,7 +5097,7 @@ dependencies = [
 "checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
-"checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "df7a791f788cb4c516f0e091301a29c2b71ef680db5e644a7d68835c8ae6dbfa"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -5032,6 +5122,7 @@ dependencies = [
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "38af00e78b66109e7184a0ee16940f41583161b7ec0518af258e4bcaed15db25"
+"checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
@@ -5065,6 +5156,7 @@ dependencies = [
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
@@ -5129,6 +5221,7 @@ dependencies = [
 "checksum vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "af464bc7be7b785c7ac72e266a6b67c4c9070155606f51655a650a6686204e35"
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ version = "0.0.1"
 dependencies = [
  "common-types 0.1.0",
  "ethcore 1.12.0",
+ "ethcore-accounts 0.1.0",
  "ethcore-miner 1.12.0",
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -74,6 +74,11 @@ using_queue = { path = "../miner/using-queue" }
 vm = { path = "vm" }
 wasm = { path = "wasm" }
 
+# Temporary dependency directly on hbbft to access the NetworkInfo struct
+# Should be removed once all data necessary to construct NetworkInfo directly in
+# the HoneyBadgerBFT consensus engine implementation is provided by smart contracts.
+hbbft = { git = "https://github.com/poanetwork/hbbft" }
+
 [dev-dependencies]
 blooms-db = { path = "../util/blooms-db" }
 criterion = "0.2"

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -27,6 +27,7 @@ common-types = { path = "../types" }
 
 [dev-dependencies]
 ethcore = { path = "..", features = ["test-helpers"] }
+ethcore-accounts = { path = "../../accounts" }
 
 [features]
 # Include tools to facilitate test setup.

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -21,6 +21,7 @@ ethcore = { path = ".." }
 ethereum-types = "0.4"
 ethcore-miner = { path = "../../miner" }
 hbbft = { git = "https://github.com/poanetwork/hbbft" }
+hbbft_testing = { git = "https://github.com/poanetwork/hbbft" }
 ethkey = { path = "../../accounts/ethkey" }
 
 common-types = { path = "../types" }
@@ -28,7 +29,8 @@ common-types = { path = "../types" }
 [dev-dependencies]
 ethcore = { path = "..", features = ["test-helpers"] }
 ethcore-accounts = { path = "../../accounts" }
-rand = "0.6.1"
+rand = "0.6.5"
+proptest = "0.9.2"
 
 [features]
 # Include tools to facilitate test setup.

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -28,6 +28,7 @@ common-types = { path = "../types" }
 [dev-dependencies]
 ethcore = { path = "..", features = ["test-helpers"] }
 ethcore-accounts = { path = "../../accounts" }
+rand = "0.6.1"
 
 [features]
 # Include tools to facilitate test setup.

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -34,7 +34,10 @@ impl HoneyBadgerBFT {
 	}
 
 	fn start_hbbft_epoch(&self, client: Arc<EngineClient>) {
-		// TODO: Use the median timestamp of all contributing hbbft nodes
+		// TODO: Instantiate a hbbft algorithm and create the pending block.
+		// After a hbbft epoch finished successfully, use the median timestamp
+		// of all contributing hbbft nodes as time stamp for the created block.
+		let _net_info = client.net_info();
 		client.create_pending_block(client.queued_transactions(), 0);
 	}
 }

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate common_types as types;
 extern crate ethcore;
+#[cfg(test)]
+extern crate ethcore_accounts as accounts;
 extern crate ethcore_miner;
 extern crate ethereum_types;
 extern crate ethkey;
@@ -25,15 +27,19 @@ pub fn init() {
 
 #[cfg(test)]
 mod tests {
-	use ethcore::client::{BlockId, BlockInfo};
-
 	use crate::test_helpers::{hbbft_client_setup, inject_transaction};
+	use ethcore::client::{BlockId, BlockInfo};
+	use ethcore::engines::signer::from_keypair;
+	use hash::keccak;
 
 	#[test]
 	fn test_miner_transaction_injection() {
 		super::init();
 
-		let (client, _, miner) = hbbft_client_setup();
+		let keypair = ethkey::KeyPair::from_secret(keccak("1").into())
+			.expect("KeyPair generation must succeed");
+
+		let (client, _, miner) = hbbft_client_setup(from_keypair(keypair));
 
 		// Verify that we actually start at block 0.
 		assert_eq!(client.chain().best_block_number(), 0);

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -60,16 +60,21 @@ mod tests {
 	fn do_test_miner_transaction_injection(seed: TestRngSeed) {
 		super::init();
 
-		// Generate a new set of cryptographic keys for threshold cryptography.
-		let mut rng = TestRng::from_seed(seed);
-		let size = 1;
-		let _net_infos = NetworkInfo::generate_map(0..size as u16, &mut rng)
-			.expect("NetworkInfo generation is expected to always succeed");
-
 		let keypair = ethkey::KeyPair::from_secret(keccak("1").into())
 			.expect("KeyPair generation must succeed");
 
 		let (client, _, miner) = hbbft_client_setup(from_keypair(keypair));
+
+		// Generate a new set of cryptographic keys for threshold cryptography.
+		let mut rng = TestRng::from_seed(seed);
+		let size = 1;
+		let net_infos = NetworkInfo::generate_map(0..size as usize, &mut rng)
+			.expect("NetworkInfo generation is expected to always succeed");
+
+		let net_info = net_infos
+			.get(&0)
+			.expect("A NetworkInfo must exist for node 0");
+		client.set_netinfo(net_info.clone());
 
 		// Verify that we actually start at block 0.
 		assert_eq!(client.chain().best_block_number(), 0);

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -5,9 +5,11 @@ extern crate ethcore_accounts as accounts;
 extern crate ethcore_miner;
 extern crate ethereum_types;
 extern crate ethkey;
+extern crate hbbft;
 extern crate inventory;
 extern crate keccak_hash as hash;
 extern crate parking_lot;
+extern crate rand;
 extern crate rustc_hex;
 extern crate serde_json;
 
@@ -31,10 +33,18 @@ mod tests {
 	use ethcore::client::{BlockId, BlockInfo};
 	use ethcore::engines::signer::from_keypair;
 	use hash::keccak;
+	use hbbft::NetworkInfo;
+	use rand;
 
 	#[test]
 	fn test_miner_transaction_injection() {
 		super::init();
+
+		// Generate a new set of cryptographic keys for threshold cryptography.
+		let mut rng = rand::thread_rng();
+		let size = 1;
+		let _net_infos = NetworkInfo::generate_map(0..size as u16, &mut rng)
+			.expect("NetworkInfo generation is expected to always succeed");
 
 		let keypair = ethkey::KeyPair::from_secret(keccak("1").into())
 			.expect("KeyPair generation must succeed");

--- a/ethcore/hbbft_engine/src/test_helpers.rs
+++ b/ethcore/hbbft_engine/src/test_helpers.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use rustc_hex::FromHex;
 
 use ethcore::client::Client;
+use ethcore::engines::signer::EngineSigner;
 use ethcore::miner::{Miner, MinerService};
 use ethcore::spec::Spec;
 use ethcore::test_helpers::generate_dummy_client_with_spec;
@@ -23,7 +24,7 @@ pub fn hbbft_client() -> std::sync::Arc<ethcore::client::Client> {
 	generate_dummy_client_with_spec(hbbft_spec)
 }
 
-pub fn hbbft_client_setup() -> (Arc<Client>, Arc<TestNotify>, Arc<Miner>) {
+pub fn hbbft_client_setup(signer: Box<EngineSigner>) -> (Arc<Client>, Arc<TestNotify>, Arc<Miner>) {
 	// Create client
 	let client = hbbft_client();
 
@@ -31,6 +32,7 @@ pub fn hbbft_client_setup() -> (Arc<Client>, Arc<TestNotify>, Arc<Miner>) {
 	{
 		let engine = client.engine();
 		engine.register_client(Arc::downgrade(&client) as _);
+		engine.set_signer(signer);
 	}
 
 	// Register notify object for capturing consensus messages

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -44,6 +44,11 @@ memory-cache = { path = "../../util/memory-cache" }
 error-chain = { version = "0.12", default-features = false }
 journaldb = { path = "../../util/journaldb" }
 
+# Temporary dependency directly on hbbft to access the NetworkInfo struct
+# Should be removed once all data necessary to construct NetworkInfo directly in
+# the HoneyBadgerBFT consensus engine implementation is provided by smart contracts.
+hbbft = { git = "https://github.com/poanetwork/hbbft" }
+
 [dev-dependencies]
 ethcore = { path = "..", features = ["test-helpers"] }
 kvdb-memorydb = "0.1"

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -46,6 +46,9 @@ use cache::Cache;
 
 pub use self::service::Service;
 
+// Temporary dependency directly on hbbft to access the NetworkInfo struct
+use hbbft::NetworkInfo;
+
 mod header_chain;
 mod service;
 
@@ -653,6 +656,14 @@ impl<T: ChainDataFetcher> ::ethcore::client::EngineClient for Client<T> {
 	}
 
 	fn create_pending_block(&self, _txns: Vec<Arc<VerifiedTransaction>>, _timestamp: u64) -> Option<ClosedBlock> {
+		warn!(target: "client", "No miner available in light clients.");
+		None
+	}
+
+	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
+	/// Should be removed as soon as all information required to build this struct
+	/// can be obtained through the chain spec or contracts.
+	fn net_info(&self) -> Option<NetworkInfo<usize>> {
 		warn!(target: "client", "No miner available in light clients.");
 		None
 	}

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -18,6 +18,7 @@
 
 use std::sync::{Weak, Arc};
 
+use ethcore::block::ClosedBlock;
 use ethcore::client::{ClientReport, EnvInfo, ClientIoMessage};
 use ethcore::engines::{epoch, EthEngine, EpochChange, EpochTransition, Proof};
 use ethcore::machine::EthereumMachine;
@@ -647,6 +648,12 @@ impl<T: ChainDataFetcher> ::ethcore::client::EngineClient for Client<T> {
 	}
 
 	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>> {
+		warn!(target: "client", "No miner available in light clients.");
 		Vec::new()
+	}
+
+	fn create_pending_block(&self, _txns: Vec<Arc<VerifiedTransaction>>, _timestamp: u64) -> Option<ClosedBlock> {
+		warn!(target: "client", "No miner available in light clients.");
+		None
 	}
 }

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -94,3 +94,6 @@ extern crate kvdb_memorydb;
 #[cfg(test)]
 extern crate tempdir;
 extern crate journaldb;
+
+// Temporary dependency directly on hbbft to access the NetworkInfo struct
+extern crate hbbft;

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1036,13 +1036,6 @@ impl Client {
 		*self.net_info.lock() = Some(net_info);
 	}
 
-	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
-	/// Should be removed as soon as all information required to build this struct
-	/// can be obtained through the chain spec or contracts.
-	pub fn netinfo(&self) -> Option<NetworkInfo<usize>> {
-		self.net_info.lock().clone()
-	}
-
 	/// Replace io channel. Useful for testing.
 	pub fn set_io_channel(&self, io_channel: IoChannel<ClientIoMessage>) {
 		*self.io_channel.write() = io_channel;
@@ -2530,6 +2523,13 @@ impl super::traits::EngineClient for Client {
 
 	fn create_pending_block(&self, txns: Vec<Arc<VerifiedTransaction>>, timestamp: u64) -> Option<ClosedBlock> {
 		self.importer.miner.create_pending_block(self, txns, timestamp)
+	}
+
+	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
+	/// Should be removed as soon as all information required to build this struct
+	/// can be obtained through the chain spec or contracts.
+	fn net_info(&self) -> Option<NetworkInfo<usize>> {
+		self.net_info.lock().clone()
 	}
 }
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -89,6 +89,9 @@ pub use blockchain::CacheSize as BlockChainCacheSize;
 pub use verification::QueueInfo as BlockQueueInfo;
 use db::Writable;
 
+// Temporary dependency directly on hbbft to access the NetworkInfo struct
+use hbbft::NetworkInfo;
+
 use_contract!(registry, "res/contracts/registrar.json");
 
 const MAX_ANCIENT_BLOCKS_QUEUE_SIZE: usize = 4096;
@@ -241,6 +244,10 @@ pub struct Client {
 	exit_handler: Mutex<Option<Box<Fn(String) + 'static + Send>>>,
 
 	importer: Importer,
+
+	// Temporary until all data necessary to construct a hbbft NetworkInfo
+	// can be obtained through chain spec or contracts.
+	net_info: Mutex<Option<NetworkInfo<usize>>>,
 }
 
 impl Importer {
@@ -793,6 +800,7 @@ impl Client {
 			exit_handler: Mutex::new(None),
 			importer,
 			config,
+			net_info: Mutex::new(None),
 		});
 
 		// prune old states.
@@ -1018,6 +1026,21 @@ impl Client {
 	#[cfg(any(test, feature = "test-helpers"))]
 	pub fn chain(&self) -> Arc<BlockChain> {
 		self.chain.read().clone()
+	}
+
+	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
+	/// Should be removed as soon as all information required to build this struct
+	/// can be obtained through the chain spec or contracts.
+	#[cfg(any(test, feature = "test-helpers"))]
+	pub fn set_netinfo(&self, net_info: NetworkInfo<usize>) {
+		*self.net_info.lock() = Some(net_info);
+	}
+
+	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
+	/// Should be removed as soon as all information required to build this struct
+	/// can be obtained through the chain spec or contracts.
+	pub fn netinfo(&self) -> Option<NetworkInfo<usize>> {
+		self.net_info.lock().clone()
 	}
 
 	/// Replace io channel. Useful for testing.

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -71,6 +71,9 @@ use trace::LocalizedTrace;
 use verification::queue::QueueInfo;
 use verification::queue::kind::blocks::Unverified;
 
+// Temporary dependency directly on hbbft to access the NetworkInfo struct
+use hbbft::NetworkInfo;
+
 /// Test client.
 pub struct TestBlockChainClient {
 	/// Blocks.
@@ -978,5 +981,12 @@ impl super::traits::EngineClient for TestBlockChainClient {
 
 	fn create_pending_block(&self, txns: Vec<Arc<VerifiedTransaction>>, timestamp: u64) -> Option<ClosedBlock> {
 		self.miner.create_pending_block(self, txns, timestamp)
+	}
+
+	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
+	/// Should be removed as soon as all information required to build this struct
+	/// can be obtained through the chain spec or contracts.
+	fn net_info(&self) -> Option<NetworkInfo<usize>> {
+		None
 	}
 }

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -52,6 +52,9 @@ use trace::LocalizedTrace;
 use verification::queue::QueueInfo as BlockQueueInfo;
 use verification::queue::kind::blocks::Unverified;
 
+// Temporary dependency directly on hbbft to access the NetworkInfo struct
+use hbbft::NetworkInfo;
+
 /// State information to be used during client query
 pub enum StateOrBlock {
 	/// State to be used, may be pending
@@ -475,6 +478,11 @@ pub trait EngineClient: Sync + Send + ChainInfo {
 
 	/// Create block and queue it for sealing. Will return None if a block is already pending.
  	fn create_pending_block(&self, txns: Vec<Arc<VerifiedTransaction>>, timestamp: u64) -> Option<ClosedBlock>;
+
+	/// Temporary access to a NetworkInfo struct required by the hbbft consensus engine
+	/// Should be removed as soon as all information required to build this struct
+	/// can be obtained through the chain spec or contracts.
+	fn net_info(&self) -> Option<NetworkInfo<usize>>;
 }
 
 /// Extended client interface for providing proofs of the state.

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -109,6 +109,9 @@ extern crate using_queue;
 extern crate vm;
 extern crate wasm;
 
+// Temporary dependency directly on hbbft to access the NetworkInfo struct
+extern crate hbbft;
+
 #[cfg(test)]
 extern crate ethcore_accounts as accounts;
 #[cfg(feature = "stratum")]


### PR DESCRIPTION
Made a NetworkInfo struct instance required for initializing hbbft algorithms available to Parity consensus engines via the EngineClient trait.

This introduces a temporary dependency on the hbbft crate to the "ethcore" and "light" crates which can be removed as soon as validator bootstrapping and management is available via specs and smart contracts.
