### PR TITLE
Skip a block when reporting malicious validators

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1771,6 +1771,8 @@ mod tests {
 			strict_empty_steps_transition: 0,
 			quorum_2_3_transition: 0,
 			randomness_contract_address: None,
+			report_malicious: BTreeMap::new(),
+			faulty_blocks_transition: BTreeMap::new(),
 		};
 
 		// mutate aura params

--- a/ethcore/src/engines/validator_set/contract.rs
+++ b/ethcore/src/engines/validator_set/contract.rs
@@ -117,13 +117,9 @@ impl ValidatorSet for ValidatorContract {
 
 	fn report_malicious(&self, address: &Address, set_block: BlockNumber, block: BlockNumber, proof: Bytes) {
 		let data = validator_report::functions::report_malicious::encode_input(*address, block, proof);
-		self.validators.queue_report((*address, block, data.clone()));
-		match self.transact(data) {
-			Ok(()) => warn!(target: "engine", "Reported malicious validator {} at block {}", address, block),
-			Err(s) => {
-				warn!(target: "engine", "Validator {} could not be reported ({}) on block {}", address, s, block);
-			}
-		}
+		self.validators.queue_report((*address, block, data));
+		trace!(target: "engine", "Queued a report on malicious validator {} at block {}",
+			   address, block);
 	}
 
 	fn report_benign(&self, address: &Address, _set_block: BlockNumber, block: BlockNumber) {

--- a/ethcore/src/engines/validator_set/contract.rs
+++ b/ethcore/src/engines/validator_set/contract.rs
@@ -117,9 +117,13 @@ impl ValidatorSet for ValidatorContract {
 
 	fn report_malicious(&self, address: &Address, set_block: BlockNumber, block: BlockNumber, proof: Bytes) {
 		let data = validator_report::functions::report_malicious::encode_input(*address, block, proof);
-		self.validators.queue_report((*address, block, data));
-		trace!(target: "engine", "Queued a report on malicious validator {} at block {}",
-			   address, block);
+		self.validators.queue_report((*address, block, data.clone()));
+		match self.transact(data) {
+			Ok(()) => warn!(target: "engine", "Reported malicious validator {} at block {}", address, block),
+			Err(s) => {
+				warn!(target: "engine", "Validator {} could not be reported ({}) on block {}", address, s, block);
+			}
+		}
 	}
 
 	fn report_benign(&self, address: &Address, _set_block: BlockNumber, block: BlockNumber) {

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -44,6 +44,8 @@ use_contract!(validator_set, "res/contracts/validator_set_aura.json");
 
 /// The maximum number of reports to keep queued.
 const MAX_QUEUED_REPORTS: usize = 10;
+/// The maximum number of returned malice reports to resend.
+const MAX_RETURNED_REPORTS: usize = 10;
 
 const MEMOIZE_CAPACITY: usize = 500;
 
@@ -334,7 +336,7 @@ impl ValidatorSet for ValidatorSafeContract {
 			vec![(self.contract_address, data)]
 		};
 		let queued_reports = self.queued_reports.lock();
-		for (_address, _block, data) in queued_reports.iter().take(10) {
+		for (_address, _block, data) in queued_reports.iter().take(MAX_RETURNED_REPORTS) {
 			returned_transactions.push((self.contract_address, data.clone()))
 		}
 		Ok(returned_transactions)

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -354,9 +354,11 @@ impl ValidatorSet for ValidatorSafeContract {
 				return false; // Report is too old and cannot be used
 			}
 			let (data, decoder) = validator_set::functions::malice_reported_for_block::call(
-				malicious_validator_address, block);
+				malicious_validator_address, block
+			);
 			match client.call_contract(BlockId::Latest, self.contract_address, data)
-					.and_then(|result| decoder.decode(&result[..]).map_err(|e| e.to_string())) {
+				.and_then(|result| decoder.decode(&result[..]).map_err(|e| e.to_string()))
+			{
 				Ok(ref reporters) if reporters.contains(&our_address) => {
 					trace!(target: "engine", "Successfully removed report from report cache");
 					false
@@ -374,10 +376,11 @@ impl ValidatorSet for ValidatorSafeContract {
 			queue.truncate(MAX_QUEUED_REPORTS);
 		}
 
-		let mut nonce = client.latest_nonce(our_address);
 		let mut resent_reports_in_block = self.resent_reports_in_block.lock();
-		if header.number() > *resent_reports_in_block {
+		// Skip at least one block after sending malicious reports last time.
+		if header.number() > *resent_reports_in_block + 1 {
 			*resent_reports_in_block = header.number();
+			let mut nonce = client.latest_nonce(our_address);
 			for (address, block, data) in &*queue {
 				debug!(target: "engine", "Retrying to report validator {} for misbehavior on block {} with nonce {}.",
 					   address, block, nonce);


### PR DESCRIPTION
1. ~~Removed instantaneous calls to `reportMalicious`.~~
2. Added a gap of at least one block after reporting malicious validators and before reporting more malicious validators.