### PR TITLE
Set gas limit according to TxPermission.blockGasLimit.

### DIFF
--- a/ethcore/call-contract/src/call_contract.rs
+++ b/ethcore/call-contract/src/call_contract.rs
@@ -18,12 +18,17 @@
 
 use bytes::Bytes;
 use ethereum_types::Address;
+use types::header::Header;
 use types::ids::BlockId;
 
 /// Provides `call_contract` method
 pub trait CallContract {
 	/// Like `call`, but with various defaults. Designed to be used for calling contracts.
 	fn call_contract(&self, id: BlockId, address: Address, data: Bytes) -> Result<Bytes, String>;
+
+	/// Makes a constant call to a contract, at the block corresponding to the given header. Fails if the block is not
+	/// in the database.
+	fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String>;
 }
 
 /// Provides information on a blockchain service and it's registry

--- a/ethcore/call-contract/src/call_contract.rs
+++ b/ethcore/call-contract/src/call_contract.rs
@@ -26,9 +26,10 @@ pub trait CallContract {
 	/// Like `call`, but with various defaults. Designed to be used for calling contracts.
 	fn call_contract(&self, id: BlockId, address: Address, data: Bytes) -> Result<Bytes, String>;
 
-	/// Makes a constant call to a contract, at the block corresponding to the given header. Fails if the block is not
-	/// in the database.
-	fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String>;
+	/// Makes a constant call to a contract, at the beginning of the block corresponding to the given header, i.e. with
+	/// the EVM state after the block's parent, but with the new header's block number. Fails if the parent is not in
+	/// the database.
+	fn call_contract_before(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String>;
 }
 
 /// Provides information on a blockchain service and it's registry

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -160,6 +160,10 @@ mod tests {
 
 	impl CallContract for DummyRegistryClient {
 		fn call_contract(&self, _id: BlockId, _address: Address, _data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
+
+		fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> {
+			Ok(vec![])
+		}
 	}
 
 	#[test]

--- a/ethcore/private-tx/src/key_server_keys.rs
+++ b/ethcore/private-tx/src/key_server_keys.rs
@@ -161,7 +161,7 @@ mod tests {
 	impl CallContract for DummyRegistryClient {
 		fn call_contract(&self, _id: BlockId, _address: Address, _data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
 
-		fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> {
+		fn call_contract_before(&self, _header: &Header, _address: Address, _data: Bytes) -> Result<Bytes, String> {
 			Ok(vec![])
 		}
 	}

--- a/ethcore/res/contracts/block_gas_limit.json
+++ b/ethcore/res/contracts/block_gas_limit.json
@@ -1,0 +1,16 @@
+[
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "blockGasLimit",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	}
+]

--- a/ethcore/res/contracts/tx_acl_gas_price.json
+++ b/ethcore/res/contracts/tx_acl_gas_price.json
@@ -43,6 +43,20 @@
 	},
 	{
 		"constant": true,
+		"inputs": [],
+		"name": "limitBlockGas",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
 		"inputs": [
 			{
 				"name": "sender",

--- a/ethcore/res/contracts/tx_acl_gas_price.json
+++ b/ethcore/res/contracts/tx_acl_gas_price.json
@@ -44,11 +44,11 @@
 	{
 		"constant": true,
 		"inputs": [],
-		"name": "limitBlockGas",
+		"name": "blockGasLimit",
 		"outputs": [
 			{
 				"name": "",
-				"type": "bool"
+				"type": "uint256"
 			}
 		],
 		"payable": false,

--- a/ethcore/res/contracts/tx_acl_gas_price.json
+++ b/ethcore/res/contracts/tx_acl_gas_price.json
@@ -43,20 +43,6 @@
 	},
 	{
 		"constant": true,
-		"inputs": [],
-		"name": "blockGasLimit",
-		"outputs": [
-			{
-				"name": "",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
 		"inputs": [
 			{
 				"name": "sender",

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1456,6 +1456,34 @@ impl CallContract for Client {
 			.map_err(|e| format!("{:?}", e))
 			.map(|executed| executed.output)
 	}
+
+	fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> {
+		let db = self.state_db.read().boxed_clone();
+
+		// early exit for pruned blocks
+		if db.is_pruned() && self.pruning_info().earliest_state > header.number() {
+			return Err(CallError::StatePruned.to_string());
+		}
+
+		let root = header.state_root();
+		let nonce = self.engine.account_start_nonce(header.number());
+		let mut state = State::from_existing(db, *root, nonce, self.factories.clone())
+			.map_err(|_| CallError::StatePruned.to_string())?;
+
+		let from = Address::default();
+		let transaction = transaction::Transaction {
+			nonce: state.nonce(&from).unwrap_or_else(|_| self.engine.account_start_nonce(0)),
+			action: Action::Call(address),
+			gas: U256::from(50_000_000),
+			gas_price: U256::default(),
+			value: U256::default(),
+			data: data,
+		}.fake_sign(from);
+
+		self.call(&transaction, Default::default(), &mut state, header)
+			.map_err(|e| format!("{:?}", e))
+			.map(|executed| executed.output)
+	}
 }
 
 impl ImportBlock for Client {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1457,7 +1457,7 @@ impl CallContract for Client {
 			.map(|executed| executed.output)
 	}
 
-	fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> {
+	fn call_contract_before(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> {
 		let db = self.state_db.read().boxed_clone();
 
 		// early exit for pruned blocks
@@ -1465,9 +1465,13 @@ impl CallContract for Client {
 			return Err(CallError::StatePruned.to_string());
 		}
 
-		let root = header.state_root();
+		let parent = self.chain.read().block_header_data(header.parent_hash()).ok_or_else(|| {
+			error!(target: "client", "Failed to call contract at {:?}'s child", header.parent_hash());
+			format!("Failed to call contract at {:?}'s child", header.parent_hash())
+		})?;
+		let root = parent.state_root();
 		let nonce = self.engine.account_start_nonce(header.number());
-		let mut state = State::from_existing(db, *root, nonce, self.factories.clone())
+		let mut state = State::from_existing(db, root, nonce, self.factories.clone())
 			.map_err(|_| CallError::StatePruned.to_string())?;
 
 		let from = Address::default();
@@ -1477,10 +1481,21 @@ impl CallContract for Client {
 			gas: U256::from(50_000_000),
 			gas_price: U256::default(),
 			value: U256::default(),
-			data: data,
+			data,
 		}.fake_sign(from);
 
-		self.call(&transaction, Default::default(), &mut state, header)
+		let env_info = EnvInfo {
+			number: header.number(),
+			author: header.author().clone(),
+			timestamp: header.timestamp(),
+			difficulty: header.difficulty().clone(),
+			last_hashes: self.build_last_hashes(&parent.hash()),
+			gas_used: U256::default(),
+			gas_limit: U256::max_value(),
+		};
+		let machine = self.engine.machine();
+
+		Self::do_virtual_call(&machine, &env_info, &mut state, &transaction, Default::default())
 			.map_err(|e| format!("{:?}", e))
 			.map(|executed| executed.output)
 	}

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -523,6 +523,7 @@ impl BlockInfo for TestBlockChainClient {
 
 impl CallContract for TestBlockChainClient {
 	fn call_contract(&self, _id: BlockId, _address: Address, _data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
+	fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
 }
 
 impl TransactionInfo for TestBlockChainClient {

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -523,7 +523,10 @@ impl BlockInfo for TestBlockChainClient {
 
 impl CallContract for TestBlockChainClient {
 	fn call_contract(&self, _id: BlockId, _address: Address, _data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
-	fn call_contract_at(&self, header: &Header, address: Address, data: Bytes) -> Result<Bytes, String> { Ok(vec![]) }
+
+	fn call_contract_before(&self, _header: &Header, _address: Address, _data: Bytes) -> Result<Bytes, String> {
+		Ok(vec![])
+	}
 }
 
 impl TransactionInfo for TestBlockChainClient {

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -32,7 +32,8 @@ use engines::{Engine, Seal, SealingState, EngineError, ConstructedVerifier};
 use engines::block_reward;
 use engines::block_reward::{BlockRewardContract, RewardKind};
 use error::{Error, ErrorKind, BlockError};
-use ethjson::{spec::StepDuration};
+use ethabi::FunctionOutputDecoder;
+use ethjson::{self, spec::StepDuration};
 use machine::{AuxiliaryData, Call, EthereumMachine};
 use hash::keccak;
 use super::signer::EngineSigner;
@@ -44,6 +45,7 @@ use itertools::{self, Itertools};
 use rlp::{encode, Decodable, DecoderError, Encodable, RlpStream, Rlp};
 use ethereum_types::{H256, H520, Address, U128, U256};
 use parking_lot::{Mutex, RwLock};
+use tx_filter::transact_acl_gas_price;
 use types::BlockNumber;
 use types::ancestry_action::AncestryAction;
 use types::header::{Header, ExtendedHeader};
@@ -1107,6 +1109,9 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 		let score = calculate_score(parent_step, current_step, current_empty_steps_len);
 		header.set_difficulty(score);
+		if let Some(gas_limit) = self.gas_limit_override(parent) {
+			header.set_gas_limit(gas_limit);
+		}
 	}
 
 	fn sealing_state(&self) -> SealingState {
@@ -1782,6 +1787,41 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		}
 
 		finalized.into_iter().map(AncestryAction::MarkFinalized).collect()
+	}
+
+	fn gas_limit_override(&self, parent: &Header) -> Option<U256> {
+		// TODO: Use target gas limit? Must exactly agree in all nodes!
+		let default_gas_limit = 10_000_000.into();
+		let client = match self.client.read().as_ref().and_then(|weak| weak.upgrade()) {
+			Some(client) => client,
+			None => {
+				debug!(target: "engine", "Unable to prepare block: missing client ref.");
+				return Some(default_gas_limit);
+			}
+		};
+		let full_client = match client.as_full_client() {
+			Some(full_client) => full_client,
+			None => {
+				debug!(target: "engine", "Failed to upgrade to BlockchainClient.");
+				return Some(default_gas_limit);
+			}
+		};
+
+		let address = match self.machine.tx_filter() {
+			Some(tx_filter) => *tx_filter.contract_address(),
+			None => {
+				debug!(target: "engine", "Not transaction filter configured. Not changing the block gas limit.");
+				return Some(default_gas_limit);
+			}
+		};
+
+		let (data, decoder) = transact_acl_gas_price::functions::limit_block_gas::call();
+		match full_client.call_contract_at(parent, address, data).ok().and_then(|value| decoder.decode(&value).ok()) {
+			Some(true) => return Some(2_000_000.into()),
+			Some(false) => (),
+			None => debug!(target: "engine", "Failed to call limitBlockGas."),
+		};
+		Some(default_gas_limit)
 	}
 }
 

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1112,7 +1112,11 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		header.set_difficulty(score);
 		if let Some(gas_limit) = self.gas_limit_override(header) {
 			trace!(target: "engine", "Setting gas limit to {} for block {}.", gas_limit, header.number());
+			let parent_gas_limit = *parent.gas_limit();
 			header.set_gas_limit(gas_limit);
+			if parent_gas_limit != gas_limit {
+				info!(target: "engine", "Block gas limit was changed from {} to {}.", parent_gas_limit, gas_limit);
+			}
 		}
 	}
 
@@ -1792,7 +1796,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 	}
 
 	fn gas_limit_override(&self, header: &Header) -> Option<U256> {
-		let (_, &address) = self.machine.params().block_gas_limit_contract.range(..header.number()).last()?;
+		let (_, &address) = self.machine.params().block_gas_limit_contract.range(..=header.number()).last()?;
 
 		let client = match self.client.read().as_ref().and_then(|weak| weak.upgrade()) {
 			Some(client) => client,

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -457,6 +457,12 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Check whether the given new block is the best block, after finalization check.
 	fn fork_choice(&self, new: &M::ExtendedHeader, best: &M::ExtendedHeader) -> ForkChoice;
+
+	/// Overrides the block gas limit. Whenever this returns `Some` for a header, the next block's gas limit must be
+	/// exactly that value.
+	fn gas_limit_override(&self, parent: &Header) -> Option<U256> {
+		None
+	}
 }
 
 /// Check whether a given block is the best block based on the default total difficulty rule.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -460,7 +460,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Overrides the block gas limit. Whenever this returns `Some` for a header, the next block's gas limit must be
 	/// exactly that value.
-	fn gas_limit_override(&self, parent: &Header) -> Option<U256> {
+	fn gas_limit_override(&self, _header: &Header) -> Option<U256> {
 		None
 	}
 }

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -108,6 +108,11 @@ impl EthereumMachine {
 	pub fn ethash_extensions(&self) -> Option<&EthashExtensions> {
 		self.ethash_extensions.as_ref()
 	}
+
+	/// Get a reference to the transaction filter, if present.
+	pub fn tx_filter(&self) -> Option<&Arc<TransactionFilter>> {
+		self.tx_filter.as_ref()
+	}
 }
 
 impl EthereumMachine {

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -79,6 +79,8 @@ pub struct CommonParams {
 	pub subprotocol_name: String,
 	/// Minimum gas limit.
 	pub min_gas_limit: U256,
+	/// The address of a contract that determines the block gas limit.
+	pub block_gas_limit_contract: BTreeMap<BlockNumber, Address>,
 	/// Fork block to check.
 	pub fork_block: Option<(BlockNumber, H256)>,
 	/// EIP150 transition block number.
@@ -243,6 +245,7 @@ impl From<ethjson::spec::Params> for CommonParams {
 			},
 			subprotocol_name: p.subprotocol_name.unwrap_or_else(|| "eth".to_owned()),
 			min_gas_limit: p.min_gas_limit.into(),
+			block_gas_limit_contract: p.block_gas_limit_contract.map(|bglc| bglc.into()).unwrap_or_default(),
 			fork_block: if let (Some(n), Some(h)) = (p.fork_block, p.fork_hash) {
 				Some((n.into(), h.into()))
 			} else {

--- a/ethcore/src/tx_filter.rs
+++ b/ethcore/src/tx_filter.rs
@@ -64,6 +64,11 @@ impl TransactionFilter {
 		)
 	}
 
+	/// Get a reference to the contract address.
+	pub fn contract_address(&self) -> &Address {
+		&self.contract_address
+	}
+
 	/// Check if transaction is allowed at given block.
 	pub fn transaction_allowed<C: BlockInfo + CallContract>(&self, parent_hash: &H256, block_number: BlockNumber, transaction: &SignedTransaction, client: &C) -> bool {
 		if block_number < self.transition_block { return true; }

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -283,13 +283,18 @@ pub fn verify_header_params(header: &Header, engine: &EthEngine, is_full: bool, 
 	if header.gas_used() > header.gas_limit() {
 		return Err(From::from(BlockError::TooMuchGasUsed(OutOfBounds { max: Some(*header.gas_limit()), min: None, found: *header.gas_used() })));
 	}
-	let min_gas_limit = engine.params().min_gas_limit;
-	if header.gas_limit() < &min_gas_limit {
-		return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds { min: Some(min_gas_limit), max: None, found: *header.gas_limit() })));
-	}
-	if let Some(limit) = engine.maximum_gas_limit() {
-		if header.gas_limit() > &limit {
-			return Err(From::from(::error::BlockError::InvalidGasLimit(OutOfBounds { min: None, max: Some(limit), found: *header.gas_limit() })));
+	// TODO: This should be called with the _parent_ instead, and the value should be checked.
+	// Alternatively, only check in `verify_parent` below, and add another function to the engine that returns `true` if
+	// the engine uses a gas limit override.
+	if engine.gas_limit_override(header).is_none() {
+		let min_gas_limit = engine.params().min_gas_limit;
+		if header.gas_limit() < &min_gas_limit {
+			return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds { min: Some(min_gas_limit), max: None, found: *header.gas_limit() })));
+		}
+		if let Some(limit) = engine.maximum_gas_limit() {
+			if header.gas_limit() > &limit {
+				return Err(From::from(::error::BlockError::InvalidGasLimit(OutOfBounds { min: None, max: Some(limit), found: *header.gas_limit() })));
+			}
 		}
 	}
 	let maximum_extra_data_size = engine.maximum_extra_data_size();
@@ -325,12 +330,10 @@ pub fn verify_header_params(header: &Header, engine: &EthEngine, is_full: bool, 
 	Ok(())
 }
 
-/// Check header parameters agains parent header.
+/// Check header parameters against parent header.
 fn verify_parent(header: &Header, parent: &Header, engine: &EthEngine) -> Result<(), Error> {
 	assert!(header.parent_hash().is_zero() || &parent.hash() == header.parent_hash(),
 			"Parent hash should already have been verified; qed");
-
-	let gas_limit_divisor = engine.params().gas_limit_bound_divisor;
 
 	if !engine.is_timestamp_valid(header.timestamp(), parent.timestamp()) {
 		let now = SystemTime::now();
@@ -348,11 +351,20 @@ fn verify_parent(header: &Header, parent: &Header, engine: &EthEngine) -> Result
 		return Err(BlockError::RidiculousNumber(OutOfBounds { min: Some(1), max: None, found: header.number() }).into());
 	}
 
-	let parent_gas_limit = *parent.gas_limit();
-	let min_gas = parent_gas_limit - parent_gas_limit / gas_limit_divisor;
-	let max_gas = parent_gas_limit + parent_gas_limit / gas_limit_divisor;
-	if header.gas_limit() <= &min_gas || header.gas_limit() >= &max_gas {
-		return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds { min: Some(min_gas), max: Some(max_gas), found: *header.gas_limit() })));
+	if let Some(gas_limit) = engine.gas_limit_override(parent) {
+		if *header.gas_limit() != gas_limit {
+			return Err(From::from(BlockError::InvalidGasLimit(
+				OutOfBounds { min: Some(gas_limit), max: Some(gas_limit), found: *header.gas_limit() }
+			)));
+		}
+	} else {
+		let gas_limit_divisor = engine.params().gas_limit_bound_divisor;
+		let parent_gas_limit = *parent.gas_limit();
+		let min_gas = parent_gas_limit - parent_gas_limit / gas_limit_divisor;
+		let max_gas = parent_gas_limit + parent_gas_limit / gas_limit_divisor;
+		if header.gas_limit() <= &min_gas || header.gas_limit() >= &max_gas {
+			return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds { min: Some(min_gas), max: Some(max_gas), found: *header.gas_limit() })));
+		}
 	}
 
 	Ok(())

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -283,10 +283,13 @@ pub fn verify_header_params(header: &Header, engine: &EthEngine, is_full: bool, 
 	if header.gas_used() > header.gas_limit() {
 		return Err(From::from(BlockError::TooMuchGasUsed(OutOfBounds { max: Some(*header.gas_limit()), min: None, found: *header.gas_used() })));
 	}
-	// TODO: This should be called with the _parent_ instead, and the value should be checked.
-	// Alternatively, only check in `verify_parent` below, and add another function to the engine that returns `true` if
-	// the engine uses a gas limit override.
-	if engine.gas_limit_override(header).is_none() {
+	if let Some(gas_limit) = engine.gas_limit_override(header) {
+		if *header.gas_limit() != gas_limit {
+			return Err(From::from(BlockError::InvalidGasLimit(
+				OutOfBounds { min: Some(gas_limit), max: Some(gas_limit), found: *header.gas_limit() }
+			)));
+		}
+	} else {
 		let min_gas_limit = engine.params().min_gas_limit;
 		if header.gas_limit() < &min_gas_limit {
 			return Err(From::from(BlockError::InvalidGasLimit(OutOfBounds { min: Some(min_gas_limit), max: None, found: *header.gas_limit() })));
@@ -351,13 +354,7 @@ fn verify_parent(header: &Header, parent: &Header, engine: &EthEngine) -> Result
 		return Err(BlockError::RidiculousNumber(OutOfBounds { min: Some(1), max: None, found: header.number() }).into());
 	}
 
-	if let Some(gas_limit) = engine.gas_limit_override(parent) {
-		if *header.gas_limit() != gas_limit {
-			return Err(From::from(BlockError::InvalidGasLimit(
-				OutOfBounds { min: Some(gas_limit), max: Some(gas_limit), found: *header.gas_limit() }
-			)));
-		}
-	} else {
+	if engine.gas_limit_override(header).is_none() {
 		let gas_limit_divisor = engine.params().gas_limit_bound_divisor;
 		let parent_gas_limit = *parent.gas_limit();
 		let min_gas = parent_gas_limit - parent_gas_limit / gas_limit_divisor;


### PR DESCRIPTION
WIP: This passes the [`posdao-test-setup`](https://github.com/poanetwork/posdao-test-setup), but both the low and the regular gas limits are still hard-coded, and the call in `verify_header_params` uses the wrong header at the moment. (See TODOs.)

It also extends the `Engine` trait in a way that's not exactly sane. And it doesn't allow for a variable gas limit.

And crucially, I don't know yet whether the state of the block hash that we use for the `limitBlockGas` call is always available in the client's database, especially if there's a fork; or whether and how this will work together with snapshots and warp sync.

Closes #119.