### PR TITLE
Generating enode://... strings for hbbft test net validators and supplying them as hbbft toml option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,9 +1724,11 @@ version = "0.0.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
+ "ethkey 0.3.0",
  "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)",
  "hbbft_testing 0.1.0 (git+https://github.com/poanetwork/hbbft.git)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/hbbft_engine/hbbft_config_generator/Cargo.toml
+++ b/ethcore/hbbft_engine/hbbft_config_generator/Cargo.toml
@@ -16,5 +16,7 @@ toml = "0.5.1"
 rand = "0.6.5"
 clap = "2"
 ethcore = { path = "../.." }
+ethkey = { path = "../../../accounts/ethkey" }
+rustc-hex = "1.0"
 
 [dev-dependencies]

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
 				nodes[m.1]
 					.client
 					.engine()
-					.handle_message(&m.0, from)
+					.handle_message(&m.0, from, None)
 					.expect("message handling to succeed");
 			}
 			n.notify.targeted_messages.write().clear();


### PR DESCRIPTION
To register reserved_peers we need the public key, the ip address and the port formatted in the "enode://" format.
The corresponding secret key is also generated and written to disk alongside the hbbft test net node.toml files.

Other noteworthy changes:
Extracted network simulator function to perform single cranks in order to set up more sophisticated test scenarios.
Implemented a test for joining a new epoch after receiving f+1 contributions.