### PR TITLE
Using the parity node id as hbbft NetworkInfo "our_id" type in the HoneyBadgerBFT Engine and toml config generator

### DIFF
--- a/ethcore/hbbft_engine/hbbft_config_generator/src/main.rs
+++ b/ethcore/hbbft_engine/hbbft_config_generator/src/main.rs
@@ -34,9 +34,8 @@ impl ToString for Enode {
 	fn to_string(&self) -> String {
 		// Example:
 		// enode://30ccdeb8c31972f570e4eea0673cd08cbe7cefc5de1d70119b39c63b1cba33b48e494e9916c0d1eab7d296774f3573da46025d1accdef2f3690bc9e6659a34b4@192.168.0.101:30300
-		let base_port = 30300usize;
-		let ip_address = format!("127.0.0.1:{}", base_port + self.idx);
-		format!("enode://{:x}@{}", self.public, ip_address)
+		let port = 30300usize + self.idx;
+		format!("enode://{:x}@127.0.0.1:{}", self.public, port)
 	}
 }
 
@@ -225,7 +224,7 @@ fn main() {
 			.expect("TOML string generation should succeed");
 		fs::write(file_name, toml_string).expect("Unable to write config file");
 
-		let file_name = format!("hbbft_validator_key{}", i);
+		let file_name = format!("hbbft_validator_key_{}", i);
 		fs::write(file_name, enode.secret.to_hex()).expect("Unable to write config file");
 	}
 }
@@ -275,9 +274,7 @@ mod tests {
 	fn test_network_info_serde() {
 		let mut rng = rand::thread_rng();
 		let enodes_map = generate_enodes(1);
-		let net_infos =
-			NetworkInfo::generate_map(enodes_map.keys().cloned().collect::<Vec<_>>(), &mut rng)
-				.unwrap();
+		let net_infos = NetworkInfo::generate_map(enodes_map.keys().cloned(), &mut rng).unwrap();
 		let net_info = net_infos.iter().nth(0).unwrap().1;
 		let toml_string = toml::to_string(&to_toml(net_info, &enodes_map, 1)).unwrap();
 		let config: TomlHbbftOptions = toml::from_str(&toml_string).unwrap();

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -169,15 +169,15 @@ impl HoneyBadgerBFT {
 					Target::Node(n) => {
 						// for debugging
 						// println!("Sending targeted message: {:?}", m.message);
-						client.send_consensus_message(ser, n, None);
+						client.send_consensus_message(ser, Some(n));
 					}
 					Target::All => {
 						// for debugging
 						// println!("Sending broadcast message: {:?}", m.message);
 
 						if let Some(ref net_info) = *self.network_info.read() {
-							for peer_id in net_info.all_ids().filter(|p| p != &net_info.our_id()) {
-								client.send_consensus_message(ser.clone(), *peer_id, None);
+							for node_id in net_info.all_ids().filter(|p| p != &net_info.our_id()) {
+								client.send_consensus_message(ser.clone(), Some(*node_id));
 							}
 						} else {
 							panic!("Network Info expected to be initialized");

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -305,7 +305,9 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 		match node_id {
 			Some(node_id) => match serde_json::from_slice(message) {
 				Ok(decoded_message) => self.process_message(decoded_message, node_id),
-				_ => Err(EngineError::UnexpectedMessage),
+				_ => Err(EngineError::MalformedMessage(
+					"Serde decoding failed.".into(),
+				)),
 			},
 			None => Err(EngineError::UnexpectedMessage),
 		}

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -136,9 +136,8 @@ impl HoneyBadgerBFT {
 
 	fn process_message(
 		&self,
-		sender_id: NodeId,
 		message: Message,
-		_node_id: Option<H512>,
+		sender_id: NodeId,
 	) -> Result<(), EngineError> {
 		let client = self
 			.client
@@ -306,12 +305,16 @@ impl Engine<EthereumMachine> for HoneyBadgerBFT {
 	fn handle_message(
 		&self,
 		message: &[u8],
-		peer_id: H512,
 		node_id: Option<H512>,
 	) -> Result<(), EngineError> {
-		match serde_json::from_slice(message) {
-			Ok(decoded_message) => self.process_message(peer_id, decoded_message, node_id),
-			_ => Err(EngineError::UnexpectedMessage),
+		match node_id {
+			Some(node_id) => {
+				match serde_json::from_slice(message) {
+					Ok(decoded_message) => self.process_message(decoded_message, node_id),
+					_ => Err(EngineError::UnexpectedMessage),
+				}
+			},
+			None => Err(EngineError::UnexpectedMessage),
 		}
 	}
 

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
 					.expect("Message target not found in nodes map")
 					.client
 					.engine()
-					.handle_message(&m.0, *from, None)
+					.handle_message(&m.0, Some(*from))
 					.expect("message handling to succeed");
 			}
 			n.notify.targeted_messages.write().clear();

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -148,12 +148,12 @@ mod tests {
 		for (from, n) in nodes.iter() {
 			for m in n.notify.targeted_messages.write().iter() {
 				nodes
-					.get(&m.1)
+					.get(&m.1.expect("The Message target node id must be set"))
 					.expect("Message target not found in nodes map")
 					.client
 					.engine()
 					.handle_message(&m.0, Some(*from))
-					.expect("message handling to succeed");
+					.expect("Message handling to succeed");
 			}
 			n.notify.targeted_messages.write().clear();
 		}

--- a/ethcore/hbbft_engine/src/test_helpers.rs
+++ b/ethcore/hbbft_engine/src/test_helpers.rs
@@ -6,7 +6,7 @@ use ethcore::spec::Spec;
 use ethcore::test_helpers::generate_dummy_client_with_spec;
 use ethcore::test_helpers::TestNotify;
 use ethereum_types::U256;
-use ethkey::{Generator, Random};
+use ethkey::{Generator, Public, Random};
 use hash::keccak;
 use hbbft::crypto::serde_impl::SerdeSecret;
 use hbbft::NetworkInfo;
@@ -34,7 +34,7 @@ pub struct HbbftTestData {
 }
 
 fn serialize_netinfo(
-	net_info: NetworkInfo<usize>,
+	net_info: NetworkInfo<Public>,
 	ips_map: &BTreeMap<usize, String>,
 ) -> HbbftOptions {
 	let hbbft_our_id = serde_json::to_string(&net_info.our_id()).unwrap();
@@ -61,7 +61,7 @@ fn serialize_netinfo(
 }
 
 pub fn hbbft_client_setup(
-	net_info: NetworkInfo<usize>,
+	net_info: NetworkInfo<Public>,
 	ips_map: &BTreeMap<usize, String>,
 ) -> HbbftTestData {
 	let client = hbbft_client();

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -633,7 +633,7 @@ impl<T: ChainDataFetcher> ::ethcore::client::EngineClient for Client<T> {
 	fn update_sealing(&self) { }
 	fn submit_seal(&self, _block_hash: H256, _seal: Vec<Vec<u8>>) { }
 	fn broadcast_consensus_message(&self, _message: Vec<u8>) { }
-	fn send_consensus_message(&self, _message: Vec<u8>, _peer_id: H512, _node_id: Option<H512>) { }
+	fn send_consensus_message(&self, _message: Vec<u8>, _node_id: Option<H512>) { }
 
 	fn epoch_transition_for(&self, parent_hash: H256) -> Option<EpochTransition> {
 		self.chain.epoch_transition_for(parent_hash).map(|(hdr, proof)| EpochTransition {

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -633,7 +633,7 @@ impl<T: ChainDataFetcher> ::ethcore::client::EngineClient for Client<T> {
 	fn update_sealing(&self) { }
 	fn submit_seal(&self, _block_hash: H256, _seal: Vec<Vec<u8>>) { }
 	fn broadcast_consensus_message(&self, _message: Vec<u8>) { }
-	fn send_consensus_message(&self, _message: Vec<u8>, _peer_id: usize, _node_id: Option<H512>) { }
+	fn send_consensus_message(&self, _message: Vec<u8>, _peer_id: H512, _node_id: Option<H512>) { }
 
 	fn epoch_transition_for(&self, parent_hash: H256) -> Option<EpochTransition> {
 		self.chain.epoch_transition_for(parent_hash).map(|(hdr, proof)| EpochTransition {

--- a/ethcore/src/client/chain_notify.rs
+++ b/ethcore/src/client/chain_notify.rs
@@ -178,7 +178,7 @@ pub trait ChainNotify : Send + Sync {
 	}
 
 	/// fires when chain sends a message to a specific peer
-	fn send(&self, _message_type: ChainMessageType, _peer_id: H512, _node_id: Option<H512>) {
+	fn send(&self, _message_type: ChainMessageType, _node_id: Option<H512>) {
 		// does nothing by default
 	}
 

--- a/ethcore/src/client/chain_notify.rs
+++ b/ethcore/src/client/chain_notify.rs
@@ -178,7 +178,7 @@ pub trait ChainNotify : Send + Sync {
 	}
 
 	/// fires when chain sends a message to a specific peer
-	fn send(&self, _message_type: ChainMessageType, _peer_id: usize, _node_id: Option<H512>) {
+	fn send(&self, _message_type: ChainMessageType, _peer_id: H512, _node_id: Option<H512>) {
 		// does nothing by default
 	}
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2282,7 +2282,7 @@ impl IoClient for Client {
 		Ok(hash)
 	}
 
-	fn queue_consensus_message(&self, message: Bytes, peer_id: usize, node_id: Option<H512>) {
+	fn queue_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>) {
 		match self.queue_consensus_message.queue(&self.io_channel.read(), 1, move |client| {
 			if let Err(e) = client.engine().handle_message(&message, peer_id, node_id) {
 				debug!(target: "poa", "Invalid message received: {}", e);
@@ -2483,7 +2483,7 @@ impl super::traits::EngineClient for Client {
 		self.notify(|notify| notify.broadcast(ChainMessageType::Consensus(message.clone())));
 	}
 
-	fn send_consensus_message(&self, message: Bytes, peer_id: usize, node_id: Option<H512>) {
+	fn send_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>) {
 		self.notify(|notify| notify.send(ChainMessageType::Consensus(message.clone()), peer_id, node_id));
 	}
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2282,9 +2282,9 @@ impl IoClient for Client {
 		Ok(hash)
 	}
 
-	fn queue_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>) {
+	fn queue_consensus_message(&self, message: Bytes, node_id: Option<H512>) {
 		match self.queue_consensus_message.queue(&self.io_channel.read(), 1, move |client| {
-			if let Err(e) = client.engine().handle_message(&message, peer_id, node_id) {
+			if let Err(e) = client.engine().handle_message(&message, node_id) {
 				debug!(target: "poa", "Invalid message received: {}", e);
 			}
 		}) {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2483,8 +2483,8 @@ impl super::traits::EngineClient for Client {
 		self.notify(|notify| notify.broadcast(ChainMessageType::Consensus(message.clone())));
 	}
 
-	fn send_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>) {
-		self.notify(|notify| notify.send(ChainMessageType::Consensus(message.clone()), peer_id, node_id));
+	fn send_consensus_message(&self, message: Bytes, node_id: Option<H512>) {
+		self.notify(|notify| notify.send(ChainMessageType::Consensus(message.clone()), node_id));
 	}
 
 	fn epoch_transition_for(&self, parent_hash: H256) -> Option<::engines::EpochTransition> {

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -923,7 +923,7 @@ impl IoClient for TestBlockChainClient {
 		self.import_block(unverified)
 	}
 
-	fn queue_consensus_message(&self, message: Bytes, peer_id: usize, node_id: Option<H512>) {
+	fn queue_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>) {
 		self.spec.engine.handle_message(&message, peer_id, node_id).unwrap();
 	}
 }
@@ -960,7 +960,7 @@ impl super::traits::EngineClient for TestBlockChainClient {
 
 	fn broadcast_consensus_message(&self, _message: Bytes) {}
 
-	fn send_consensus_message(&self, _message: Bytes, _peer_id: usize, _node_id: Option<H512>) {
+	fn send_consensus_message(&self, _message: Bytes, _peer_id: H512, _node_id: Option<H512>) {
 		// TODO: allow test to intercept the message to relay it to other test clients
 	}
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -960,7 +960,7 @@ impl super::traits::EngineClient for TestBlockChainClient {
 
 	fn broadcast_consensus_message(&self, _message: Bytes) {}
 
-	fn send_consensus_message(&self, _message: Bytes, _peer_id: H512, _node_id: Option<H512>) {
+	fn send_consensus_message(&self, _message: Bytes, _node_id: Option<H512>) {
 		// TODO: allow test to intercept the message to relay it to other test clients
 	}
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -923,8 +923,8 @@ impl IoClient for TestBlockChainClient {
 		self.import_block(unverified)
 	}
 
-	fn queue_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>) {
-		self.spec.engine.handle_message(&message, peer_id, node_id).unwrap();
+	fn queue_consensus_message(&self, message: Bytes, node_id: Option<H512>) {
+		self.spec.engine.handle_message(&message, node_id).unwrap();
 	}
 }
 

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -197,7 +197,7 @@ pub trait IoClient: Sync + Send {
 	fn queue_ancient_block(&self, block_bytes: Unverified, receipts_bytes: Bytes) -> EthcoreResult<H256>;
 
 	/// Queue conensus engine message.
-	fn queue_consensus_message(&self, message: Bytes, peer_id: usize, node_id: Option<H512>);
+	fn queue_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>);
 }
 
 /// Provides recently seen bad blocks.
@@ -455,7 +455,7 @@ pub trait EngineClient: Sync + Send + ChainInfo + Nonce {
 	fn broadcast_consensus_message(&self, message: Bytes);
 
 	/// Send a consensus message to the specified peer
-	fn send_consensus_message(&self, message: Bytes, _peer_id: usize, node_id: Option<H512>);
+	fn send_consensus_message(&self, message: Bytes, _peer_id: H512, node_id: Option<H512>);
 
 	/// Get the transition to the epoch the given parent hash is part of
 	/// or transitions to.

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -455,7 +455,7 @@ pub trait EngineClient: Sync + Send + ChainInfo + Nonce {
 	fn broadcast_consensus_message(&self, message: Bytes);
 
 	/// Send a consensus message to the specified peer
-	fn send_consensus_message(&self, message: Bytes, _peer_id: H512, node_id: Option<H512>);
+	fn send_consensus_message(&self, message: Bytes, node_id: Option<H512>);
 
 	/// Get the transition to the epoch the given parent hash is part of
 	/// or transitions to.

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -197,7 +197,7 @@ pub trait IoClient: Sync + Send {
 	fn queue_ancient_block(&self, block_bytes: Unverified, receipts_bytes: Bytes) -> EthcoreResult<H256>;
 
 	/// Queue conensus engine message.
-	fn queue_consensus_message(&self, message: Bytes, peer_id: H512, node_id: Option<H512>);
+	fn queue_consensus_message(&self, message: Bytes, node_id: Option<H512>);
 }
 
 /// Provides recently seen bad blocks.

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1155,7 +1155,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		SealingState::Ready
 	}
 
-	fn handle_message(&self, rlp: &[u8], _peer_id: H512, _node_id: Option<H512>) -> Result<(), EngineError> {
+	fn handle_message(&self, rlp: &[u8], _node_id: Option<H512>) -> Result<(), EngineError> {
 		fn fmt_err<T: ::std::fmt::Debug>(x: T) -> EngineError {
 			EngineError::MalformedMessage(format!("{:?}", x))
 		}

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1155,7 +1155,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		SealingState::Ready
 	}
 
-	fn handle_message(&self, rlp: &[u8], _peer_id: usize, _node_id: Option<H512>) -> Result<(), EngineError> {
+	fn handle_message(&self, rlp: &[u8], _peer_id: H512, _node_id: Option<H512>) -> Result<(), EngineError> {
 		fn fmt_err<T: ::std::fmt::Debug>(x: T) -> EngineError {
 			EngineError::MalformedMessage(format!("{:?}", x))
 		}

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -408,7 +408,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Handle any potential consensus messages;
 	/// updating consensus state and potentially issuing a new one.
-	fn handle_message(&self, _message: &[u8], _peer_id: usize, node: Option<H512>) -> Result<(), EngineError> { Err(EngineError::UnexpectedMessage) }
+	fn handle_message(&self, _message: &[u8], _peer_id: H512, _node: Option<H512>) -> Result<(), EngineError> { Err(EngineError::UnexpectedMessage) }
 
 	/// Find out if the block is a proposal block and should not be inserted into the DB.
 	/// Takes a header of a fully verified block.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -408,7 +408,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 
 	/// Handle any potential consensus messages;
 	/// updating consensus state and potentially issuing a new one.
-	fn handle_message(&self, _message: &[u8], _peer_id: H512, _node: Option<H512>) -> Result<(), EngineError> { Err(EngineError::UnexpectedMessage) }
+	fn handle_message(&self, _message: &[u8], _node_id: Option<H512>) -> Result<(), EngineError> { Err(EngineError::UnexpectedMessage) }
 
 	/// Find out if the block is a proposal block and should not be inserted into the DB.
 	/// Takes a header of a fully verified block.

--- a/ethcore/src/test_helpers.rs
+++ b/ethcore/src/test_helpers.rs
@@ -504,7 +504,7 @@ pub struct TestNotify {
 	/// Messages store
 	pub messages: RwLock<Vec<Bytes>>,
 	/// Targeted messages store
-	pub targeted_messages: RwLock<Vec<(Bytes, usize)>>,
+	pub targeted_messages: RwLock<Vec<(Bytes, H512)>>,
 }
 
 impl ChainNotify for TestNotify {
@@ -517,7 +517,7 @@ impl ChainNotify for TestNotify {
 		self.messages.write().push(data);
 	}
 
-	fn send(&self, message: ChainMessageType, peer_id: usize, node_id: Option<H512>) {
+	fn send(&self, message: ChainMessageType, peer_id: H512, _node_id: Option<H512>) {
 		let data = match message {
 			ChainMessageType::Consensus(data) => data,
 			ChainMessageType::SignedPrivateTransaction(_, data) => data,

--- a/ethcore/src/test_helpers.rs
+++ b/ethcore/src/test_helpers.rs
@@ -504,7 +504,7 @@ pub struct TestNotify {
 	/// Messages store
 	pub messages: RwLock<Vec<Bytes>>,
 	/// Targeted messages store
-	pub targeted_messages: RwLock<Vec<(Bytes, H512)>>,
+	pub targeted_messages: RwLock<Vec<(Bytes, Option<H512>)>>,
 }
 
 impl ChainNotify for TestNotify {
@@ -517,12 +517,12 @@ impl ChainNotify for TestNotify {
 		self.messages.write().push(data);
 	}
 
-	fn send(&self, message: ChainMessageType, peer_id: H512, _node_id: Option<H512>) {
+	fn send(&self, message: ChainMessageType, node_id: Option<H512>) {
 		let data = match message {
 			ChainMessageType::Consensus(data) => data,
 			ChainMessageType::SignedPrivateTransaction(_, data) => data,
 			ChainMessageType::PrivateTransaction(_, data) => data,
 		};
-		self.targeted_messages.write().push((data, peer_id));
+		self.targeted_messages.write().push((data, node_id));
 	}
 }

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -587,7 +587,7 @@ impl ChainNotify for EthSync {
 		});
 	}
 
-	fn send(&self, _message_type: ChainMessageType, _peer_id: usize, node_id: Option<H512>) {
+	fn send(&self, _message_type: ChainMessageType, _peer_id: H512, node_id: Option<H512>) {
 		self.network.with_context(WARP_SYNC_PROTOCOL_ID, |context| {
 			let peer_ids = self.network.connected_peers();
 			let node_ids = peer_ids.iter().map(|&x|context.session_info(x).unwrap().id).collect::<Vec<Option<H512>>>();

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -587,7 +587,7 @@ impl ChainNotify for EthSync {
 		});
 	}
 
-	fn send(&self, _message_type: ChainMessageType, _peer_id: H512, node_id: Option<H512>) {
+	fn send(&self, _message_type: ChainMessageType, node_id: Option<H512>) {
 		self.network.with_context(WARP_SYNC_PROTOCOL_ID, |context| {
 			let peer_ids = self.network.connected_peers();
 			let node_ids = peer_ids.iter().map(|&x|context.session_info(x).unwrap().id).collect::<Vec<Option<H512>>>();

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -112,7 +112,7 @@ impl SyncHandler {
 	/// Called when peer sends us new consensus packet
 	pub fn on_consensus_packet(io: &mut SyncIo, peer_id: PeerId, r: &Rlp, node_id: Option<H512>) {
 		trace!(target: "sync", "Received consensus packet from {:?}", peer_id);
-		io.chain().queue_consensus_message(r.as_raw().to_vec(), peer_id, node_id);
+		io.chain().queue_consensus_message(r.as_raw().to_vec(), node_id.unwrap(), node_id);
 	}
 
 	/// Called by peer when it is disconnecting

--- a/ethcore/sync/src/chain/handler.rs
+++ b/ethcore/sync/src/chain/handler.rs
@@ -112,7 +112,7 @@ impl SyncHandler {
 	/// Called when peer sends us new consensus packet
 	pub fn on_consensus_packet(io: &mut SyncIo, peer_id: PeerId, r: &Rlp, node_id: Option<H512>) {
 		trace!(target: "sync", "Received consensus packet from {:?}", peer_id);
-		io.chain().queue_consensus_message(r.as_raw().to_vec(), node_id.unwrap(), node_id);
+		io.chain().queue_consensus_message(r.as_raw().to_vec(), node_id);
 	}
 
 	/// Called by peer when it is disconnecting


### PR DESCRIPTION
Eliminated the redundant "peer_id" argument from consensus message sending/receiving functions as well.