### PR TITLE
Stabilized HoneyBadgerBFT Engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "common-types 0.1.0",
  "ethcore 1.12.0",
  "ethcore-accounts 0.1.0",
+ "ethcore-io 1.12.0",
  "ethcore-miner 1.12.0",
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hbbft"
+version = "0.1.1"
+source = "git+https://github.com/poanetwork/hbbft?rev=70783871150a125d366f02bdd415d27f7464e417#70783871150a125d366f02bdd415d27f7464e417"
+dependencies = [
+ "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "init_with 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reed-solomon-erasure 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hbbft_config_generator"
 version = "0.0.1"
 dependencies = [
@@ -1744,7 +1765,7 @@ dependencies = [
  "ethcore-miner 1.12.0",
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
- "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)",
+ "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft?rev=70783871150a125d366f02bdd415d27f7464e417)",
  "hbbft_testing 0.1.0 (git+https://github.com/poanetwork/hbbft.git)",
  "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5048,6 +5069,7 @@ dependencies = [
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b03501f6e1a2a97f1618879aba3156f14ca2847faa530c4e28859638bd11483"
 "checksum hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft.git)" = "<none>"
+"checksum hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft?rev=70783871150a125d366f02bdd415d27f7464e417)" = "<none>"
 "checksum hbbft_testing 0.1.0 (git+https://github.com/poanetwork/hbbft.git)" = "<none>"
 "checksum heapsize 0.4.2 (git+https://github.com/cheme/heapsize.git?branch=ec-macfix)" = "<none>"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -11,24 +11,24 @@ authors = [
 [lib]
 
 [dependencies]
-rustc-hex = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-parking_lot = "0.6"
-inventory = "0.1"
-keccak-hash = "0.1"
-ethereum-types = "0.4"
+common-types = { path = "../types" }
 ethcore = { path = ".." }
 ethcore-io = { path = "../../util/io" }
 ethcore-miner = { path = "../../miner" }
+ethereum-types = "0.4"
+ethkey = { path = "../../accounts/ethkey" }
 hbbft = { git = "https://github.com/poanetwork/hbbft", rev = "70783871150a125d366f02bdd415d27f7464e417" }
 hbbft_testing = { git = "https://github.com/poanetwork/hbbft" }
-ethkey = { path = "../../accounts/ethkey" }
-common-types = { path = "../types" }
-rlp = { version = "0.3.0", features = ["ethereum"] }
+inventory = "0.1"
 itertools = "0.5"
-rand = "0.6.5"
+keccak-hash = "0.1"
 log = "0.4"
+parking_lot = "0.6"
+rand = "0.6.5"
+rlp = { version = "0.3.0", features = ["ethereum"] }
+rustc-hex = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 ethcore = { path = "..", features = ["test-helpers"] }

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -20,7 +20,7 @@ keccak-hash = "0.1"
 ethcore = { path = ".." }
 ethereum-types = "0.4"
 ethcore-miner = { path = "../../miner" }
-hbbft = { git = "https://github.com/poanetwork/hbbft" }
+hbbft = { git = "https://github.com/poanetwork/hbbft", rev = "70783871150a125d366f02bdd415d27f7464e417" }
 hbbft_testing = { git = "https://github.com/poanetwork/hbbft" }
 ethkey = { path = "../../accounts/ethkey" }
 common-types = { path = "../types" }

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -17,8 +17,9 @@ serde_json = "1.0"
 parking_lot = "0.6"
 inventory = "0.1"
 keccak-hash = "0.1"
-ethcore = { path = ".." }
 ethereum-types = "0.4"
+ethcore = { path = ".." }
+ethcore-io = { path = "../../util/io" }
 ethcore-miner = { path = "../../miner" }
 hbbft = { git = "https://github.com/poanetwork/hbbft", rev = "70783871150a125d366f02bdd415d27f7464e417" }
 hbbft_testing = { git = "https://github.com/poanetwork/hbbft" }

--- a/ethcore/hbbft_engine/res/honey_badger_bft.json
+++ b/ethcore/hbbft_engine/res/honey_badger_bft.json
@@ -4,8 +4,9 @@
 		"external": {
 			"name": "HoneyBadgerBFT",
 			"params": {
-				"minimumBlockTime": 2,
+				"minimumBlockTime": 0,
 				"transactionQueueSizeTrigger": 1,
+				"isUnitTest": true
 			}
 		}
 	},

--- a/ethcore/hbbft_engine/res/honey_badger_bft.json
+++ b/ethcore/hbbft_engine/res/honey_badger_bft.json
@@ -4,12 +4,8 @@
 		"external": {
 			"name": "HoneyBadgerBFT",
 			"params": {
-				"validators": {
-					"list": [
-						"0x7d577a597b2742b498cb5cf0c26cdcd726d39e6e",
-						"0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1"
-					]
-				}
+				"minimumBlockTime": 2,
+				"transactionQueueSizeTrigger": 1,
 			}
 		}
 	},

--- a/ethcore/hbbft_engine/src/contribution.rs
+++ b/ethcore/hbbft_engine/src/contribution.rs
@@ -24,7 +24,7 @@ pub fn unix_now_secs() -> u64 {
 	UNIX_EPOCH.elapsed().expect("Time not available").as_secs()
 }
 
-/// Returns the current UNIX Epoch time, in seconds.
+/// Returns the current UNIX Epoch time, in milliseconds.
 pub fn unix_now_millis() -> u128 {
 	UNIX_EPOCH
 		.elapsed()

--- a/ethcore/hbbft_engine/src/contribution.rs
+++ b/ethcore/hbbft_engine/src/contribution.rs
@@ -20,8 +20,16 @@ pub(super) struct Contribution {
 const RANDOM_BYTES_PER_EPOCH: usize = 4 * 20;
 
 /// Returns the current UNIX Epoch time, in seconds.
-fn unix_now_secs() -> u64 {
+pub fn unix_now_secs() -> u64 {
 	UNIX_EPOCH.elapsed().expect("Time not available").as_secs()
+}
+
+/// Returns the current UNIX Epoch time, in seconds.
+pub fn unix_now_millis() -> u128 {
+	UNIX_EPOCH
+		.elapsed()
+		.expect("Time not available")
+		.as_millis()
 }
 
 impl Contribution {

--- a/ethcore/hbbft_engine/src/hbbft_engine.rs
+++ b/ethcore/hbbft_engine/src/hbbft_engine.rs
@@ -267,7 +267,8 @@ impl HoneyBadgerBFT {
 				self.send_contribution(client, honey_badger);
 			}
 		} else {
-			error!(target: "engine", "Attempt to start an epoch without the honey badger algorithm being set.");
+			// The Honey Badger algorithm is expected not to be available on non-validator nodes.
+			// error!(target: "engine", "Attempt to start an epoch without the honey badger algorithm being set.");
 		}
 	}
 }

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate common_types as types;
 extern crate ethcore;
+extern crate ethcore_io as io;
 extern crate ethcore_miner;
 extern crate ethereum_types;
 extern crate ethkey;

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -144,7 +144,8 @@ mod tests {
 
 	fn crank_network_single_step(nodes: &BTreeMap<Public, HbbftTestData>) {
 		for (from, n) in nodes {
-			for m in n.notify.targeted_messages.write().drain(..) {
+			let mut targeted_messages = n.notify.targeted_messages.write();
+			for m in targeted_messages.drain(..) {
 				nodes
 					.get(&m.1.expect("The Message target node id must be set"))
 					.expect("Message target not found in nodes map")

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -660,7 +660,7 @@ impl<T: ChainDataFetcher> ::ethcore::client::EngineClient for Client<T> {
 		Vec::new()
 	}
 
-	fn create_pending_block(&self, _txns: Vec<SignedTransaction>, _timestamp: u64) -> Option<ClosedBlock> {
+	fn create_pending_block_at(&self, _txns: Vec<SignedTransaction>, _timestamp: u64, _block_number: u64) -> Option<ClosedBlock> {
 		warn!(target: "client", "No miner available in light clients.");
 		None
 	}

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2505,8 +2505,8 @@ impl super::traits::EngineClient for Client {
 		self.importer.miner.queued_transactions()
 	}
 
-	fn create_pending_block(&self, txns: Vec<SignedTransaction>, timestamp: u64) -> Option<ClosedBlock> {
-		self.importer.miner.create_pending_block(self, txns, timestamp)
+	fn create_pending_block_at(&self, txns: Vec<SignedTransaction>, timestamp: u64, block_number: u64) -> Option<ClosedBlock> {
+		self.importer.miner.create_pending_block_at(self, txns, timestamp, block_number)
 	}
 
 	/// Returns the currently configured options for the hbbft consensus engine.

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -982,8 +982,8 @@ impl super::traits::EngineClient for TestBlockChainClient {
 		self.miner.queued_transactions()
 	}
 
-	fn create_pending_block(&self, txns: Vec<SignedTransaction>, timestamp: u64) -> Option<ClosedBlock> {
-		self.miner.create_pending_block(self, txns, timestamp)
+	fn create_pending_block_at(&self, txns: Vec<SignedTransaction>, timestamp: u64, block_number: u64) -> Option<ClosedBlock> {
+		self.miner.create_pending_block_at(self, txns, timestamp, block_number)
 	}
 
 	/// Returns the currently configured options for the hbbft consensus engine.

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -477,7 +477,7 @@ pub trait EngineClient: Sync + Send + ChainInfo + Nonce {
 	fn queued_transactions(&self) -> Vec<Arc<VerifiedTransaction>>;
 
 	/// Create block and queue it for sealing. Will return None if a block is already pending.
- 	fn create_pending_block(&self, txns: Vec<SignedTransaction>, timestamp: u64) -> Option<ClosedBlock>;
+ 	fn create_pending_block_at(&self, txns: Vec<SignedTransaction>, timestamp: u64, block_number: u64) -> Option<ClosedBlock>;
 
 	/// Returns the currently configured options for the hbbft consensus engine.
 	/// TODO: Should be removed as soon as all information required to build this struct

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -618,11 +618,7 @@ impl Miner {
 		let mut sealing = self.sealing.lock();
 		let chain_info = chain.chain_info();
 		let parent_block_number = block_number - 1;
-		let parent_header = if let Some(block_header) = chain.block_header(BlockId::Number(parent_block_number)) {
-			block_header
-		} else {
-			return None;
-		};
+		let parent_header = chain.block_header(BlockId::Number(parent_block_number))?;
 		let parent_hash = parent_header.hash();
 
 		match sealing.queue.get_pending_if(|b| b.block().header().parent_hash() == &parent_hash) {

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -613,13 +613,19 @@ impl Miner {
 
 	/// Creates a new block and sets it as pending for sealing.
 	/// Returns false if a pending block already exists.
-	pub fn create_pending_block<C>(&self, chain: &C, txns: Vec<SignedTransaction>, timestamp: u64) -> Option<ClosedBlock>
+	pub fn create_pending_block_at<C>(&self, chain: &C, txns: Vec<SignedTransaction>, timestamp: u64, block_number: u64) -> Option<ClosedBlock>
 		where C: BlockChain + CallContract + BlockProducer + SealedBlockImporter + Nonce + Sync {
 		let mut sealing = self.sealing.lock();
 		let chain_info = chain.chain_info();
-		let best_hash = chain_info.best_block_hash;
+		let parent_block_number = block_number - 1;
+		let parent_header = if let Some(block_header) = chain.block_header(BlockId::Number(parent_block_number)) {
+			block_header
+		} else {
+			return None;
+		};
+		let parent_hash = parent_header.hash();
 
-		match sealing.queue.get_pending_if(|b| b.block().header().parent_hash() == &best_hash) {
+		match sealing.queue.get_pending_if(|b| b.block().header().parent_hash() == &parent_hash) {
 			Some(_) => {
 				trace!(target: "miner", "create_pending_block: Already have a pending block!");
 				None
@@ -628,8 +634,16 @@ impl Miner {
 				trace!(target: "miner", "create_pending_block: Making a new block");
 
 				let (mut open_block, engine_pending) = self.create_open_block(chain)?;
+				// Only proceed with blocks at the desired block number.
+				if open_block.header().number() != block_number {
+					return None
+				}
 
+				// Make sure the new timestamp is larger than the parent's timestamp.
+				let parent_timestamp = parent_header.timestamp();
+				let timestamp = cmp::max(timestamp, parent_timestamp + 1);
 				open_block.set_timestamp(timestamp);
+
 				let min_tx_gas: U256 = self.engine.schedule(chain_info.best_block_number).tx_gas.into();
 
 				// Add transactions to the new block


### PR DESCRIPTION
* Implemented create_pending_block_at() function to assure a new block is created with the desired parent. Avoids creating a block which already has been imported through gossip from other validator nodes.
* Added and implemented options to configure a minimum block time to avoid TimestampOverflow errors.
* Implemented handling of Target::AllExcept hbbft messages.

Note: Make sure to configure the node.toml "reseal_min_period" mining setting to a setting lower than the "minimumBlockTime" HoneyBadgerBFT chain spec setting, or the value "reseal_min_period" will restrict your minimum block time.