### PR TITLE
Ellipsize NodeId hex digits in Debug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "ethkey 0.3.0",
  "hbbft 0.1.1 (git+https://github.com/poanetwork/hbbft?rev=70783871150a125d366f02bdd415d27f7464e417)",
  "hbbft_testing 0.1.0 (git+https://github.com/poanetwork/hbbft.git)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/hbbft_engine/Cargo.toml
+++ b/ethcore/hbbft_engine/Cargo.toml
@@ -19,6 +19,7 @@ ethereum-types = "0.4"
 ethkey = { path = "../../accounts/ethkey" }
 hbbft = { git = "https://github.com/poanetwork/hbbft", rev = "70783871150a125d366f02bdd415d27f7464e417" }
 hbbft_testing = { git = "https://github.com/poanetwork/hbbft" }
+hex_fmt = "0.3.0"
 inventory = "0.1"
 itertools = "0.5"
 keccak-hash = "0.1"

--- a/ethcore/hbbft_engine/src/lib.rs
+++ b/ethcore/hbbft_engine/src/lib.rs
@@ -33,12 +33,27 @@ mod sealing;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers;
 
+use std::fmt;
+
 use ethcore::engines::registry::EnginePlugin;
 use ethkey::Public;
 
 pub use hbbft_engine::HoneyBadgerBFT;
 
-type NodeId = Public;
+#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct NodeId(pub Public);
+
+impl fmt::Debug for NodeId {
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		write!(f, "{:6}", hex_fmt::HexFmt(&self.0))
+	}
+}
+
+impl fmt::Display for NodeId {
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		write!(f, "NodeId({})", self.0)
+	}
+}
 
 /// Registers the `HoneyBadgerBFT` engine. This must be called before parsing the chain spec.
 pub fn init() {


### PR DESCRIPTION
This shortens node IDs in `Debug` output, which otherwise would print all 128 hex digits. It now looks like this: `proposer_id: be..77`.