### PR TITLE
Move blockGasLimitContract to AuRa params and rename it

### DIFF
--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -79,8 +79,6 @@ pub struct CommonParams {
 	pub subprotocol_name: String,
 	/// Minimum gas limit.
 	pub min_gas_limit: U256,
-	/// The address of a contract that determines the block gas limit.
-	pub block_gas_limit_contract: BTreeMap<BlockNumber, Address>,
 	/// Fork block to check.
 	pub fork_block: Option<(BlockNumber, H256)>,
 	/// EIP150 transition block number.
@@ -244,7 +242,6 @@ impl From<ethjson::spec::Params> for CommonParams {
 			},
 			subprotocol_name: p.subprotocol_name.unwrap_or_else(|| "eth".to_owned()),
 			min_gas_limit: p.min_gas_limit.into(),
-			block_gas_limit_contract: p.block_gas_limit_contract.map(|bglc| bglc.into()).unwrap_or_default(),
 			fork_block: if let (Some(n), Some(h)) = (p.fork_block, p.fork_hash) {
 				Some((n.into(), h.into()))
 			} else {

--- a/json/src/spec/authority_round.rs
+++ b/json/src/spec/authority_round.rs
@@ -76,18 +76,23 @@ pub struct AuthorityRoundParams {
 	/// The block number at which the consensus engine switches from AuRa to AuRa with POSDAO
 	/// modifications.
 	pub posdao_transition: Option<Uint>,
+	/// The addresses of contracts that determine the block gas limit starting from the block number
+	/// associated with each of those contracts.
+	pub block_gas_limit_contract_transitions: Option<BTreeMap<Uint, Address>>,
 }
 
 /// Authority engine deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuthorityRound {
-	/// Ethash params.
+	/// Authority Round parameters.
 	pub params: AuthorityRoundParams,
 }
 
 #[cfg(test)]
 mod tests {
+	use std::str::FromStr;
+
 	use ethereum_types::{U256, H160};
 	use uint::Uint;
 	use serde_json;
@@ -108,7 +113,11 @@ mod tests {
 				"validateStepTransition": 150,
 				"blockReward": 5000000,
 				"maximumUncleCountTransition": 10000000,
-				"maximumUncleCount": 5
+				"maximumUncleCount": 5,
+				"blockGasLimitContractTransitions": {
+					"10": "0x1000000000000000000000000000000000000001",
+					"20": "0x2000000000000000000000000000000000000002"
+				}
 			}
 		}"#;
 
@@ -119,5 +128,10 @@ mod tests {
 		assert_eq!(deserialized.params.immediate_transitions, None);
 		assert_eq!(deserialized.params.maximum_uncle_count_transition, Some(Uint(10_000_000.into())));
 		assert_eq!(deserialized.params.maximum_uncle_count, Some(Uint(5.into())));
+		let expected_bglc =
+			[(Uint(10.into()), Address(H160::from_str("1000000000000000000000000000000000000001").unwrap())),
+			 (Uint(20.into()), Address(H160::from_str("2000000000000000000000000000000000000002").unwrap()))];
+		assert_eq!(deserialized.params.block_gas_limit_contract_transitions,
+				   Some(expected_bglc.to_vec().into_iter().collect()));
 	}
 }

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -34,8 +34,6 @@ pub struct Params {
 	pub maximum_extra_data_size: Uint,
 	/// Minimum gas limit.
 	pub min_gas_limit: Uint,
-	/// The address of a contract that determines the block gas limit.
-	pub block_gas_limit_contract: Option<BlockGasLimitContract>,
 
 	/// Network id.
 	#[serde(rename = "networkID")]
@@ -131,28 +129,6 @@ pub struct Params {
 	pub kip6_transition: Option<Uint>,
 }
 
-/// A contract that determines block gas limits can be configured either as a single address, or as a map, assigning
-/// to each starting block number the contract address that should be used from that block on.
-#[derive(Debug, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields, untagged)]
-pub enum BlockGasLimitContract {
-	/// A single address for a block gas limit contract.
-	Single(Address),
-	/// A map from block numbers to the contract addresses that should be used for the gas limit after that block.
-	Transitions(BTreeMap<Uint, Address>),
-}
-
-impl From<BlockGasLimitContract> for BTreeMap<u64, H160> {
-	fn from(contract: BlockGasLimitContract) -> Self {
-		match contract {
-			BlockGasLimitContract::Single(Address(addr)) => iter::once((0, addr)).collect(),
-			BlockGasLimitContract::Transitions(transitions) => {
-				transitions.into_iter().map(|(Uint(block), Address(addr))| (block.into(), addr)).collect()
-			}
-		}
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use std::str::FromStr;
@@ -160,7 +136,7 @@ mod tests {
 	use uint::Uint;
 	use ethereum_types::{U256, H160};
 	use hash::Address;
-	use spec::params::{BlockGasLimitContract, Params};
+	use spec::params::Params;
 
 	#[test]
 	fn params_deserialization() {
@@ -173,11 +149,7 @@ mod tests {
 			"accountStartNonce": "0x01",
 			"gasLimitBoundDivisor": "0x20",
 			"maxCodeSize": "0x1000",
-			"wasmActivationTransition": "0x1010",
-			"blockGasLimitContract": {
-				"10": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				"20": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-			}
+			"wasmActivationTransition": "0x1010"
 		}"#;
 
 		let deserialized: Params = serde_json::from_str(s).unwrap();


### PR DESCRIPTION
This is a backport from https://github.com/paritytech/parity-ethereum/pull/10928.

The new name of the parameter is `blockGasLimitContractTransitions`. @varasev, @phahulin, please use the new name in spec files.