### PR TITLE
Added an option to the Engine trait to use the author only as engine signer

### DIFF
--- a/ethcore/engine/src/engine.rs
+++ b/ethcore/engine/src/engine.rs
@@ -393,6 +393,9 @@ pub trait Engine: Sync + Send {
 	fn decode_transaction(&self, transaction: &[u8]) -> Result<UnverifiedTransaction, transaction::Error> {
 		self.machine().decode_transaction(transaction)
 	}
+
+	/// Use the author as signer as well as block author.
+	fn use_block_author(&self) -> bool { true }
 }
 
 /// Verifier for all blocks within an epoch with self-contained state.

--- a/ethcore/engines/hbbft/src/hbbft_engine.rs
+++ b/ethcore/engines/hbbft/src/hbbft_engine.rs
@@ -618,6 +618,10 @@ impl Engine for HoneyBadgerBFT {
 	fn params(&self) -> &CommonParams {
 		self.machine.params()
 	}
+
+	fn use_block_author(&self) -> bool {
+		false
+	}
 }
 
 #[cfg(test)]

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -422,7 +422,7 @@ impl Miner {
 		let params = self.params.read().clone();
 
 		let open_block = match chain.prepare_open_block(
-			params.author,
+			if self.engine.use_block_author() { params.author } else { Address::zero() },
 			params.gas_range_target,
 			params.extra_data,
 		) {


### PR DESCRIPTION
Setting the "engine_signer" in the parity mining options also sets the address as the author of blocks produced by the validator. This causes generated blocks to differ between validators, and sealing to fail.

Added an option to the Engine trait to signal that the "engine_signer" should *not* be used as block author.