### PR TITLE
Backport upstream's impl to clear engine signer.

### DIFF
--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -193,12 +193,8 @@ impl Engine<EthereumMachine> for BasicAuthority {
 		self.validators.register_client(client);
 	}
 
-	fn set_signer(&self, signer: Box<EngineSigner>) {
-		*self.signer.write() = Some(signer);
-	}
-
-	fn clear_signer(&self) {
-		*self.signer.write() = Default::default();
+	fn set_signer(&self, signer: Option<Box<dyn EngineSigner>>) {
+		*self.signer.write() = signer;
 	}
 
 	fn sign(&self, hash: H256) -> Result<Signature, Error> {
@@ -268,7 +264,7 @@ mod tests {
 
 		let spec = new_test_authority();
 		let engine = &*spec.engine;
-		engine.set_signer(Box::new((Arc::new(tap), addr, "".into())));
+		engine.set_signer(Some(Box::new((Arc::new(tap), addr, "".into()))));
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
@@ -286,9 +282,9 @@ mod tests {
 
 		let engine = new_test_authority().engine;
 		assert_eq!(SealingState::NotReady, engine.sealing_state());
-		engine.set_signer(Box::new((Arc::new(tap), authority, "".into())));
+		engine.set_signer(Some(Box::new((Arc::new(tap), authority, "".into()))));
 		assert_eq!(SealingState::Ready, engine.sealing_state());
-		engine.clear_signer();
+		engine.set_signer(None);
 		assert_eq!(SealingState::NotReady, engine.sealing_state());
 	}
 }

--- a/ethcore/src/engines/clique/mod.rs
+++ b/ethcore/src/engines/clique/mod.rs
@@ -720,9 +720,14 @@ impl Engine<EthereumMachine> for Clique {
 		}
 	}
 
-	fn set_signer(&self, signer: Box<EngineSigner>) {
-		trace!(target: "engine", "set_signer: {}", signer.address());
-		*self.signer.write() = Some(signer);
+	fn set_signer(&self, signer: Option<Box<dyn EngineSigner>>) {
+		let mut current_signer = self.signer.write();
+		if let Some(signer) = signer.as_ref() {
+			trace!(target: "engine", "set_signer: {:?}", signer.address());
+		} else if let Some(signer) = &*current_signer {
+			trace!(target: "engine", "set_signer: cleared; previous signer: {:?})", signer.address());
+		}
+		*current_signer = signer;
 	}
 
 	fn register_client(&self, client: Weak<EngineClient>) {

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -441,10 +441,7 @@ pub trait Engine<M: Machine>: Sync + Send {
 	fn handle_message(&self, _message: &[u8]) -> Result<(), EngineError> { Err(EngineError::UnexpectedMessage) }
 
 	/// Register a component which signs consensus messages.
-	fn set_signer(&self, _signer: Box<EngineSigner>) {}
-
-	/// Unregisters the engine signer address to stop signing consensus messages.
-	fn clear_signer(&self) {}
+	fn set_signer(&self, _signer: Option<Box<EngineSigner>>) {}
 
 	/// Sign using the EngineSigner, to be used for consensus tx signing.
 	fn sign(&self, _hash: H256) -> Result<Signature, M::Error> { unimplemented!() }

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -881,30 +881,39 @@ impl miner::MinerService for Miner {
 		self.params.write().extra_data = extra_data;
 	}
 
-	fn set_author(&self, author: Author) {
-		self.params.write().author = author.address();
+	fn set_author<T: Into<Option<Author>>>(&self, author: T) {
+		let author_opt = author.into();
+		self.params.write().author = author_opt.as_ref().map(Author::address).unwrap_or_default();
 
-		if let Author::Sealer(signer) = author {
-			if self.engine.sealing_state() != SealingState::External {
-				// Enable sealing
-				self.sealing.lock().enabled = true;
-				// --------------------------------------------------------------------------
-				// | NOTE Code below may require author and sealing locks                   |
-				// | (some `Engine`s call `EngineClient.update_sealing()`)                  |
-				// | Make sure to release the locks before calling that method.             |
-				// --------------------------------------------------------------------------
-				self.engine.set_signer(signer);
-			} else {
-				warn!("Setting an EngineSigner while Engine does not require one.");
+		match author_opt {
+			Some(Author::Sealer(signer)) => {
+				if self.engine.sealing_state() != SealingState::External {
+					// Enable sealing
+					self.sealing.lock().enabled = true;
+					// --------------------------------------------------------------------------
+					// | NOTE Code below may require author and sealing locks                   |
+					// | (some `Engine`s call `EngineClient.update_sealing()`)                  |
+					// | Make sure to release the locks before calling that method.             |
+					// --------------------------------------------------------------------------
+					self.engine.set_signer(Some(signer));
+				} else {
+					warn!("Setting an EngineSigner while Engine does not require one.");
+				}
 			}
-		}
-	}
-
-	fn clear_author(&self) {
-		self.params.write().author = Default::default();
-		if self.engine.sealing_state() != SealingState::External {
-			self.sealing.lock().enabled = false;
-			self.engine.clear_signer();
+			Some(Author::External(_address)) => (),
+			None => {
+				// Clear the author.
+				if self.engine.sealing_state() != SealingState::External {
+					// Disable sealing.
+					self.sealing.lock().enabled = false;
+					// --------------------------------------------------------------------------
+					// | NOTE Code below may require author and sealing locks                   |
+					// | (some `Engine`s call `EngineClient.update_sealing()`)                  |
+					// | Make sure to release the locks before calling that method.             |
+					// --------------------------------------------------------------------------
+					self.engine.set_signer(None);
+				}
+			}
 		}
 	}
 

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -131,10 +131,7 @@ pub trait MinerService : Send + Sync {
 	/// Set info necessary to sign consensus messages and block authoring.
 	///
 	/// On chains where sealing is done externally (e.g. PoW) we provide only reward beneficiary.
-	fn set_author(&self, author: Author);
-
-	/// Clears the engine signer and stops signing.
-	fn clear_author(&self);
+	fn set_author<T: Into<Option<Author>>>(&self, author: T);
 
 	// Transaction Pool
 

--- a/rpc/src/v1/impls/parity_set.rs
+++ b/rpc/src/v1/impls/parity_set.rs
@@ -166,7 +166,7 @@ impl<C, M, U, F> ParitySet for ParitySetClient<C, M, U, F> where
 	}
 
 	fn clear_engine_signer(&self) -> Result<bool> {
-		self.miner.clear_author();
+		self.miner.set_author(None);
 		Ok(true)
 	}
 

--- a/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/rpc/src/v1/tests/helpers/miner_service.rs
@@ -123,15 +123,14 @@ impl MinerService for TestMinerService {
 		self.authoring_params.read().clone()
 	}
 
-	fn set_author(&self, author: miner::Author) {
-		self.authoring_params.write().author = author.address();
-		if let miner::Author::Sealer(signer) = author {
-			*self.signer.write() = Some(signer);
+	fn set_author<T: Into<Option<miner::Author>>>(&self, author: T) {
+		let author_opt = author.into();
+		self.authoring_params.write().author = author_opt.as_ref().map(miner::Author::address).unwrap_or_default();
+		match author_opt {
+			Some(miner::Author::Sealer(signer)) => *self.signer.write() = Some(signer),
+			Some(miner::Author::External(_addr)) => (),
+			None => *self.signer.write() = None,
 		}
-	}
-
-	fn clear_author(&self) {
-		*self.authoring_params.write() = Default::default();
 	}
 
 	fn set_extra_data(&self, extra_data: Bytes) {


### PR DESCRIPTION
Original commit messages:

RPC method parity_clearEngineSigner

Add RPC method parity_clearEngineSigner
Fixes https://github.com/poanetwork/parity-ethereum/issues/113

corrected the return type of clear_author

review comment responses and a rebase fix

removed a spurrious warning

moved clear_signer functionality to set_signer

Merge clear_author into MinerService::set_author.

Add trace logs to Clique::set_signer.

Clique: Don't lock signer multiple times.